### PR TITLE
Add logic for DynamoDB ARNs

### DIFF
--- a/awacs/dynamodb.py
+++ b/awacs/dynamodb.py
@@ -4,9 +4,22 @@
 # See LICENSE file for full license.
 
 from aws import Action
+from aws import ARN as BASE_ARN
 
 service_name = 'Amazon DynamoDB'
 prefix = 'dynamodb'
+
+
+class ARN(BASE_ARN):
+    def __init__(self, region, account, table=None, index=None):
+        sup = super(ARN, self)
+        resource = '*'
+        if table:
+            resource = 'table/' + table
+            if index:
+                resource += '/index/' + index
+        sup.__init__(prefix, region=region, account=account, resource=resource)
+
 
 BatchGetItem = Action(prefix, 'BatchGetItem')
 CreateTable = Action(prefix, 'CreateTable')


### PR DESCRIPTION
See:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/UsingIAMWithDDB.html

I also decided not to name the ARN object 'DynamoDB_ARN' or anything
like that, and instead went with just 'ARN' since the class is already
stored in the dynamodb module.  Kind of waffling on whether or not that
was the right thing to do, since it's not how this is handled elsewhere,
but it seems like it makes sense. If you're going to deal with multiple
ARNs, say in SDB & Dynamo, then it seems like you should be doing:

from awacs.sdb import ARN as SDB_ARN
from awacs.dynamodb import ARN as DynamoDB_ARN

Let me know what you guys think about that.
