### PR TITLE
Added new autoscaling API endpoints

### DIFF
--- a/awacs/autoscaling.py
+++ b/awacs/autoscaling.py
@@ -8,6 +8,8 @@ from aws import Action
 service_name = 'Auto Scaling'
 prefix = 'autoscaling'
 
+AttachInstances = Action(prefix, 'AttachInstances')
+CompleteLifecycleAction = Action(prefix, 'CompleteLifecycleAction')
 CreateAutoScalingGroup = Action(prefix, 'CreateAutoScalingGroup')
 CreateLaunchConfiguration = Action(prefix, 'CreateLaunchConfiguration')
 CreateOrUpdateScalingTrigger = \
@@ -15,12 +17,14 @@ CreateOrUpdateScalingTrigger = \
 CreateOrUpdateTags = Action(prefix, 'CreateOrUpdateTags')
 DeleteAutoScalingGroup = Action(prefix, 'DeleteAutoScalingGroup')
 DeleteLaunchConfiguration = Action(prefix, 'DeleteLaunchConfiguration')
+DeleteLifecycleHook = Action(prefix, 'DeleteLifecycleHook')
 DeleteNotificationConfiguration = \
     Action(prefix, 'DeleteNotificationConfiguration')
 DeletePolicy = Action(prefix, 'DeletePolicy')
 DeleteScheduledAction = Action(prefix, 'DeleteScheduledAction')
 DeleteTags = Action(prefix, 'DeleteTags')
 DeleteTrigger = Action(prefix, 'DeleteTrigger')
+DescribeAccountLimits = Action(prefix, 'DescribeAccountLimits')
 DescribeAdjustmentTypes = Action(prefix, 'DescribeAdjustmentTypes')
 DescribeAutoScalingGroups = Action(prefix, 'DescribeAutoScalingGroups')
 DescribeAutoScalingInstances = \
@@ -29,6 +33,9 @@ DescribeAutoScalingNotificationTypes = \
     Action(prefix, 'DescribeAutoScalingNotificationTypes')
 DescribeLaunchConfigurations = \
     Action(prefix, 'DescribeLaunchConfigurations')
+DescribeLifecycleHookTypes = \
+    Action(prefix, 'DescribeLifecycleHookTypes')
+DescribeLifecycleHooks = Action(prefix, 'DescribeLifecycleHooks')
 DescribeMetricCollectionTypes = \
     Action(prefix, 'DescribeMetricCollectionTypes')
 DescribeNotificationConfigurations = \
@@ -39,15 +46,23 @@ DescribeScalingProcessTypes = \
     Action(prefix, 'DescribeScalingProcessTypes')
 DescribeScheduledActions = Action(prefix, 'DescribeScheduledActions')
 DescribeTags = Action(prefix, 'DescribeTags')
+DescribeTerminationPolicyTypes = \
+    Action(prefix, 'DescribeTerminationPolicyTypes')
 DescribeTriggers = Action(prefix, 'DescribeTriggers')
+DetachInstances = Action(prefix, 'DetachInstances')
 DisableMetricsCollection = Action(prefix, 'DisableMetricsCollection')
 EnableMetricsCollection = Action(prefix, 'EnableMetricsCollection')
+EnterPolicy = Action(prefix, 'EnterPolicy')
 ExecutePolicy = Action(prefix, 'ExecutePolicy')
+ExitPolicy = Action(prefix, 'ExitPolicy')
+PutLifecycleHook = Action(prefix, 'PutLifecycleHook')
 PutNotificationConfiguration = \
     Action(prefix, 'PutNotificationConfiguration')
 PutScalingPolicy = Action(prefix, 'PutScalingPolicy')
 PutScheduledUpdateGroupAction = \
     Action(prefix, 'PutScheduledUpdateGroupAction')
+RecordLifecycleActionHeartbeat = \
+    Action(prefix, 'RecordLifecycleActionHeartbeat')
 ResumeProcesses = Action(prefix, 'ResumeProcesses')
 SetDesiredCapacity = Action(prefix, 'SetDesiredCapacity')
 SetInstanceHealth = Action(prefix, 'SetInstanceHealth')


### PR DESCRIPTION
As listed in full from http://docs.aws.amazon.com/AutoScaling/latest/APIReference/Welcome.html.

DeleteTrigger and DescribeTriggers are not listed anymore - they can probably be removed?
