### PR TITLE
Allow JSONrepr objects in ARNs

### DIFF
--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -43,8 +43,14 @@ class Action(AWSHelperFn):
 
 class BaseARN(AWSHelperFn):
     def __init__(self, service, resource, region='', account=''):
-        self.data = "arn:aws:%s:%s:%s:%s" % (
-            service, region, account, resource)
+        data = (service, region, account, resource)
+        parts = []
+        for d in data:
+            v = d
+            if hasattr(d, 'JSONrepr'):
+                v = d.JSONrepr()
+            parts.append(v)
+        self.data = "arn:aws:%s:%s:%s:%s" % tuple(parts)
 
     def JSONrepr(self):
         return self.data


### PR DESCRIPTION
Per this, it seems that Ref's and Joins are allowed in IAM policies in
Cloudformation:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-iam.html#scenario-bucket-policy

This is my attempt to make awacs allow it as well.

Fixes GH-15

If anyone has any ideas for a simple example where this could be used that'd be awesome.  Right now, this is all the testing I've done:

```python
>>> from awacs.dynamodb import ARN
>>> from troposphere import Ref
>>> a = ARN(Ref("Region"), Ref("Account"))
>>> from awacs import awsencode
>>> import json
>>> print json.dumps(a, cls=awsencode, indent=4, sort_keys=True)
"arn:aws:dynamodb:{'Ref': 'Region'}:{'Ref': 'Account'}:*"
```