### PR TITLE
Allow blank region/account for dynamodb ARN

### DIFF
--- a/awacs/dynamodb.py
+++ b/awacs/dynamodb.py
@@ -11,7 +11,7 @@ prefix = 'dynamodb'
 
 
 class ARN(BaseARN):
-    def __init__(self, region, account, table=None, index=None):
+    def __init__(self, region='', account='', table=None, index=None):
         sup = super(ARN, self)
         resource = '*'
         if table:


### PR DESCRIPTION
This is how most ARNs behave.
