### PR TITLE
Updating action set

### DIFF
--- a/examples/ecs.py
+++ b/examples/ecs.py
@@ -1,18 +1,23 @@
 # Example taken from AWS docs:
-# http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAM_policies.html#instance_IAM_role
+# http://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html
 
 from awacs.aws import Allow
 from awacs.aws import Policy, Statement
-import awacs.ecs as ecs
+import awacs.ecs as aecs
+import awacs.ecr as aecr
+import awacs.logs as alogs
 
 
 pd = Policy(
     Statement=[
         Statement(
             Effect=Allow,
-            Action=[ecs.CreateCluster, ecs.RegisterContainerInstance,
-                    ecs.DeregisterContainerInstance, ecs.DiscoverPollEndpoint,
-                    ecs.Action("Submit*"), ecs.Poll],
+            Action=[aecs.CreateCluster, aecs.DeregisterContainerInstance,
+                    aecs.DiscoverPollEndpoint, aecs.Poll, aecs.RegisterContainerInstance,
+                    aecs.StartTelemetrySession, aecr.GetAuthorizationToken,
+                    aecr.BatchCheckLayerAvailability, aecr.GetDownloadUrlForLayer,
+                    aecr.BatchGetImage, alogs.CreateLogStream, alogs.PutLogEvents,
+                    aecs.Action("Submit*")],
             Resource=["*"]
         )
     ]

--- a/examples/ecs.py
+++ b/examples/ecs.py
@@ -12,11 +12,18 @@ pd = Policy(
     Statement=[
         Statement(
             Effect=Allow,
-            Action=[aecs.CreateCluster, aecs.DeregisterContainerInstance,
-                    aecs.DiscoverPollEndpoint, aecs.Poll, aecs.RegisterContainerInstance,
-                    aecs.StartTelemetrySession, aecr.GetAuthorizationToken,
-                    aecr.BatchCheckLayerAvailability, aecr.GetDownloadUrlForLayer,
-                    aecr.BatchGetImage, alogs.CreateLogStream, alogs.PutLogEvents,
+            Action=[aecs.CreateCluster,
+                    aecs.DeregisterContainerInstance,
+                    aecs.DiscoverPollEndpoint,
+                    aecs.Poll,
+                    aecs.RegisterContainerInstance,
+                    aecs.StartTelemetrySession,
+                    aecr.GetAuthorizationToken,
+                    aecr.BatchCheckLayerAvailability,
+                    aecr.GetDownloadUrlForLayer,
+                    aecr.BatchGetImage,
+                    alogs.CreateLogStream,
+                    alogs.PutLogEvents,
                     aecs.Action("Submit*")],
             Resource=["*"]
         )


### PR DESCRIPTION
AWS has apparently added a bunch of actions to this role since the example was first published.

Also changed imports to 'a' imports, for fewer collisions with Troposphere.
