### PR TITLE
Don't try to use `type` since it is never set

### DIFF
--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -80,8 +80,10 @@ class AWSObject(object):
             else:
                 self._raise_type(name, value, expected_type)
 
-        raise AttributeError("%s object does not support attribute %s" %
-                             (self.type, name))
+        full_class_name = "%s.%s" % (self.__class__.__module__,
+                                     self.__class__.__name__)
+        raise AttributeError("'%s' object does not support attribute '%s'" %
+                             (full_class_name, name))
 
     def _raise_type(self, name, value, expected_type):
         raise TypeError('%s is %s, expected %s' %

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,6 +10,6 @@ class TestAWSObject(unittest.TestCase):
             Policy(Version='2012-10-17', statement=[])
 
         self.assertEqual(
-            exc.exception.message,
+            exc.exception.args[0],
             "'awacs.aws.Policy' object does not support attribute 'statement'"
         )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,15 @@
+import unittest
+
+from awacs.aws import Policy
+
+
+class TestAWSObject(unittest.TestCase):
+    def test_invalid_property(self):
+        with self.assertRaises(AttributeError) as exc:
+            # statement should be Statement
+            Policy(Version='2012-10-17', statement=[])
+
+        self.assertEqual(
+            exc.exception.message,
+            "'awacs.aws.Policy' object does not support attribute 'statement'"
+        )


### PR DESCRIPTION
This is more of a workaround than a full fix - not sure what `type` was
ever intended for on AWSObject, but it's never set, so trying to use it
is not a good idea.

This should fix #32