### PR TITLE
Define hash and equality

### DIFF
--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -136,7 +136,8 @@ class AWSHelperFn(object):
             return data
 
     def to_json(self, indent=4, sort_keys=True):
-        return json.dumps(self, cls=awsencode, indent=indent, sort_keys=sort_keys)
+        p = self
+        return json.dumps(p, cls=awsencode, indent=indent, sort_keys=sort_keys)
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -10,7 +10,6 @@ import types
 
 __version__ = "0.7.2"
 
-
 valid_names = re.compile(r'^[a-zA-Z0-9]+$')
 
 
@@ -100,6 +99,22 @@ class AWSObject(object):
         self.validate()
         return self.resource
 
+    def to_json(self, indent=4, sort_keys=True):
+        p = self.properties
+        return json.dumps(p, cls=awsencode, indent=indent, sort_keys=sort_keys)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.to_json() == other.to_json()
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(self.to_json())
+
 
 class AWSProperty(AWSObject):
     """
@@ -119,6 +134,21 @@ class AWSHelperFn(object):
             return data.name
         else:
             return data
+
+    def to_json(self, indent=4, sort_keys=True):
+        return json.dumps(self, cls=awsencode, indent=indent, sort_keys=sort_keys)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.to_json() == other.to_json()
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(self.to_json())
 
 
 class awsencode(json.JSONEncoder):

--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -3,10 +3,9 @@
 #
 # See LICENSE file for full license.
 
-import json
 import warnings
-from . import AWSHelperFn, AWSProperty, awsencode
 
+from . import AWSHelperFn, AWSProperty
 
 # Policy effect constants.
 Allow = "Allow"

--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -169,10 +169,6 @@ class Policy(AWSProperty):
         'Version': (basestring, False),
     }
 
-    def to_json(self, indent=4, sort_keys=True):
-        p = self.properties
-        return json.dumps(p, cls=awsencode, indent=indent, sort_keys=sort_keys)
-
     def JSONrepr(self):
         return self.properties
 

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,0 +1,113 @@
+import unittest
+
+from awacs import s3, ec2, iam
+from awacs.aws import PolicyDocument, Statement, Action, Condition
+from awacs.aws import StringEquals, StringLike
+
+
+class TestEquality(unittest.TestCase):
+    def test_condition_equality(self):
+        self.assertEqualWithHash(Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
+                                 Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])))
+
+        self.assertNotEqualWithHash(Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
+                                    Condition(StringLike("s3:prefix", ["other/${aws:username}/*"])))
+
+        self.assertNotEqualWithHash(Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
+                                    Condition(StringEquals("s3:prefix", ["home/${aws:username}/*"])))
+
+    def test_arn_equality(self):
+        self.assertEqualWithHash(s3.ARN("myBucket"), s3.ARN("myBucket"))
+
+        self.assertNotEqualWithHash(s3.ARN("myBucket"), s3.ARN("myOtherBucket"))
+
+        self.assertEqualWithHash(ec2.ARN("some-resource", "some-region", "some-account"),
+                                 ec2.ARN("some-resource", "some-region", "some-account"))
+
+        self.assertNotEqualWithHash(ec2.ARN("some-resource", "some-region", "some-account"),
+                                    ec2.ARN("some-resource", "some-other-region", "some-account"))
+
+        self.assertNotEqualWithHash(ec2.ARN("some-resource", "some-region", "some-account"),
+                                    iam.ARN("some-resource", "some-region", "some-account"))
+
+    def test_action_equality(self):
+        self.assertEqualWithHash(Action('autoscaling', 'DescribeLaunchConfigurations'),
+                                 Action('autoscaling', 'DescribeLaunchConfigurations'))
+
+        self.assertNotEqualWithHash(Action('autoscaling', 'DescribeLaunchConfigurations'),
+                                    Action('ec2', 'DescribeInstances'))
+
+    def test_statement_equality(self):
+        one = Statement(
+            Effect="Allow",
+            Action=[
+                Action('autoscaling', 'DescribeLaunchConfigurations'),
+            ],
+            Resource=["*"]
+        )
+        one_again = Statement(
+            Effect="Allow",
+            Action=[
+                Action('autoscaling', 'DescribeLaunchConfigurations'),
+            ],
+            Resource=["*"]
+        )
+        two = Statement(
+            Effect="Allow",
+            Action=[
+                Action('ec2', 'DescribeInstances'),
+            ],
+            Resource=["*"]
+        )
+
+        self.assertEqualWithHash(one, one_again)
+        self.assertNotEqualWithHash(one, two)
+
+    def test_policy_document_equality(self):
+        one = PolicyDocument(
+            Version="2012-10-17",
+            Statement=[
+                Statement(
+                    Effect="Allow",
+                    Action=[
+                        Action('autoscaling', 'DescribeLaunchConfigurations'),
+                    ],
+                    Resource=["*"]
+                )
+            ]
+        )
+        one_again = PolicyDocument(
+            Version="2012-10-17",
+            Statement=[
+                Statement(
+                    Effect="Allow",
+                    Action=[
+                        Action('autoscaling', 'DescribeLaunchConfigurations'),
+                    ],
+                    Resource=["*"]
+                )
+            ]
+        )
+
+        two = PolicyDocument(
+            Version="2012-10-17",
+            Statement=[
+                Statement(
+                    Effect="Allow",
+                    Action=[
+                        Action('ec2', 'DescribeInstances'),
+                    ],
+                    Resource=["*"]
+                )
+            ]
+        )
+        self.assertEqualWithHash(one, one_again)
+        self.assertNotEqualWithHash(one, two)
+
+    def assertEqualWithHash(self, one, two):
+        self.assertTrue(one == two)
+        self.assertEqual(hash(one), hash(two))
+
+    def assertNotEqualWithHash(self, one, two):
+        self.assertTrue(one != two)
+        self.assertNotEqual(hash(one), hash(two))

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -7,35 +7,45 @@ from awacs.aws import StringEquals, StringLike
 
 class TestEquality(unittest.TestCase):
     def test_condition_equality(self):
-        self.assertEqualWithHash(Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
-                                 Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])))
+        self.assertEqualWithHash(
+            Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
+            Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])))
 
-        self.assertNotEqualWithHash(Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
-                                    Condition(StringLike("s3:prefix", ["other/${aws:username}/*"])))
+        self.assertNotEqualWithHash(
+            Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
+            Condition(StringLike("s3:prefix", ["other/${aws:username}/*"])))
 
-        self.assertNotEqualWithHash(Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
-                                    Condition(StringEquals("s3:prefix", ["home/${aws:username}/*"])))
+        self.assertNotEqualWithHash(
+            Condition(StringLike("s3:prefix", ["home/${aws:username}/*"])),
+            Condition(StringEquals("s3:prefix", ["home/${aws:username}/*"])))
 
     def test_arn_equality(self):
-        self.assertEqualWithHash(s3.ARN("myBucket"), s3.ARN("myBucket"))
+        self.assertEqualWithHash(
+            s3.ARN("myBucket"), s3.ARN("myBucket"))
 
-        self.assertNotEqualWithHash(s3.ARN("myBucket"), s3.ARN("myOtherBucket"))
+        self.assertNotEqualWithHash(
+            s3.ARN("myBucket"), s3.ARN("myOtherBucket"))
 
-        self.assertEqualWithHash(ec2.ARN("some-resource", "some-region", "some-account"),
-                                 ec2.ARN("some-resource", "some-region", "some-account"))
+        self.assertEqualWithHash(
+            ec2.ARN("some-resource", "some-region", "some-account"),
+            ec2.ARN("some-resource", "some-region", "some-account"))
 
-        self.assertNotEqualWithHash(ec2.ARN("some-resource", "some-region", "some-account"),
-                                    ec2.ARN("some-resource", "some-other-region", "some-account"))
+        self.assertNotEqualWithHash(
+            ec2.ARN("some-resource", "some-region", "some-account"),
+            ec2.ARN("some-resource", "some-other-region", "some-account"))
 
-        self.assertNotEqualWithHash(ec2.ARN("some-resource", "some-region", "some-account"),
-                                    iam.ARN("some-resource", "some-region", "some-account"))
+        self.assertNotEqualWithHash(
+            ec2.ARN("some-resource", "some-region", "some-account"),
+            iam.ARN("some-resource", "some-region", "some-account"))
 
     def test_action_equality(self):
-        self.assertEqualWithHash(Action('autoscaling', 'DescribeLaunchConfigurations'),
-                                 Action('autoscaling', 'DescribeLaunchConfigurations'))
+        self.assertEqualWithHash(
+            Action('autoscaling', 'DescribeLaunchConfigurations'),
+            Action('autoscaling', 'DescribeLaunchConfigurations'))
 
-        self.assertNotEqualWithHash(Action('autoscaling', 'DescribeLaunchConfigurations'),
-                                    Action('ec2', 'DescribeInstances'))
+        self.assertNotEqualWithHash(
+            Action('autoscaling', 'DescribeLaunchConfigurations'),
+            Action('ec2', 'DescribeInstances'))
 
     def test_statement_equality(self):
         one = Statement(


### PR DESCRIPTION
This PR adds `__eq__`, `__ne__` and `__hash__` methods on the `AWSObject` and `AWSHelperFn` base classes. Equality is defined on the JSON representation of the object. 
To do this, this PR also moves up the `to_json` method up to the base classes. This extends the public interface as now pretty much every object has a `to_json` method. I didn't see a big downside to this but if you have any doubts just let me know and we can change it to a private method. 

**Why?** I am using awacs in a tool that generates PolicyDocuments. Being able to put PolicyDocuments and their parts into sets or assert on equality in tests would help a lot. 