### PR TITLE
refactor helpers/trust.py and adds application_autoscaling

### DIFF
--- a/awacs/helpers/trust.py
+++ b/awacs/helpers/trust.py
@@ -18,54 +18,48 @@ def make_simple_assume_policy(*principals):
     )
 
 
-def get_codedeploy_assumerole_policy():
-    """ Helper function for building the AWS CodeDeploy AssumeRole Policy
-    """
+def make_service_domain_name(service, region=''):
+    """ Helper function for creating proper service domain names. """
+    tld = ".com.cn" if region == "cn-north-1" else ".com"
+    return "{}.amazonaws{}".format(service, tld)
 
-    service = 'codedeploy.amazonaws.com'
-    policy = Policy(
-        Statement=[make_simple_assume_statement(service)]
-    )
-    return policy
+
+def get_codedeploy_assumerole_policy(region=''):
+    """ Helper function for building the AWS CodeDeploy AssumeRole Policy. """
+    service = make_service_domain_name('codedeploy', region)
+    return make_simple_assume_policy(service)
 
 
 def get_default_assumerole_policy(region=''):
-    """ Helper function for building the Default AssumeRole Policy
+    """ Helper function for building the Default AssumeRole Policy.
 
     Taken from here:
         https://github.com/boto/boto/blob/develop/boto/iam/connection.py#L29
     Used to allow ec2 instances to assume the roles in their InstanceProfile.
     """
-
-    service = 'ec2.amazonaws.com'
-    if region == 'cn-north-1':
-        service = 'ec2.amazonaws.com.cn'
-
+    service = make_service_domain_name('ec2', region)
     return make_simple_assume_policy(service)
 
 
 def get_ecs_assumerole_policy(region=''):
-    """ Helper function for building the ECS AssumeRole Policy
-    """
-
-    service = 'ecs.amazonaws.com'
+    """ Helper function for building the ECS AssumeRole Policy. """
+    service = make_service_domain_name('ecs', region)
     return make_simple_assume_policy(service)
 
 
 def get_ecs_task_assumerole_policy(region=''):
-    """ Helper function for building the AssumeRole Policy for ECS Tasks
-    """
-
-    service = 'ecs-tasks.amazonaws.com'
-    policy = Policy(
-        Statement=[make_simple_assume_statement(service)]
-    )
-    return policy
+    """ Helper function for building the AssumeRole Policy for ECS Tasks. """
+    service = make_service_domain_name('ecs-tasks', region)
+    return make_simple_assume_policy(service)
 
 
 def get_lambda_assumerole_policy(region=''):
-    """ Helper function for building the AWS Lambda AssumeRole Policy
-    """
+    """ Helper function for building the AWS Lambda AssumeRole Policy. """
+    service = make_service_domain_name('lambda', region)
+    return make_simple_assume_policy(service)
 
-    service = 'lambda.amazonaws.com'
+
+def get_application_autoscaling_assumerole_policy(region=''):
+    """ Helper function for building the AWS Lambda AssumeRole Policy. """
+    service = make_service_domain_name('application-autoscaling', region)
     return make_simple_assume_policy(service)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,10 @@
 import unittest
 
-from awacs.helpers.trust import get_default_assumerole_policy
+from awacs.helpers.trust import (
+    get_default_assumerole_policy,
+    get_application_autoscaling_assumerole_policy,
+    make_service_domain_name,
+)
 
 
 def get_policy_service(policy):
@@ -10,6 +14,22 @@ def get_policy_service(policy):
 
 
 class TestTrustHelpers(unittest.TestCase):
+
+    def test_make_service_domain_name(self):
+        self.assertEqual(
+            'ec2.amazonaws.com',
+            make_service_domain_name('ec2')
+        )
+        self.assertEqual(
+            'ec2.amazonaws.com.cn',
+            make_service_domain_name('ec2', region='cn-north-1')
+        )
+        # proove function is future proof.
+        self.assertEqual(
+            'ec2.amazonaws.com',
+            make_service_domain_name('ec2', region='us-east-15')
+        )
+
     def test_get_default_assumerole_policy(self):
         default_policy = get_default_assumerole_policy('us-east-1')
         cn_policy = get_default_assumerole_policy('cn-north-1')
@@ -18,6 +38,13 @@ class TestTrustHelpers(unittest.TestCase):
                          'ec2.amazonaws.com')
         self.assertEqual(get_policy_service(cn_policy),
                          'ec2.amazonaws.com.cn')
+
+    def test_get_application_autoscaling_assumerole_policy(self):
+        assumerole_policy = get_application_autoscaling_assumerole_policy()
+        self.assertEqual(
+            'application-autoscaling.amazonaws.com',
+            get_policy_service(assumerole_policy)
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a new function called `get_application_autoscaling_assumerole_policy` which is useful to have for DynamoDB Autoscaling:

Lifted from here:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-examples-application-autoscaling