### PR TITLE
Output type error correctly

### DIFF
--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -95,7 +95,7 @@ class AWSObject(object):
         for k, v in self.props.items():
             if v[1] and k not in self.properties:
                 raise ValueError("Resource %s required in type %s" %
-                                 (k, self.type))
+                                 (k, type(self)))
         self.validate()
         return self.resource
 


### PR DESCRIPTION
This seems to fix https://github.com/cloudtools/awacs/issues/96 to provide a meaningful error. I'm not sure if this change might adversely affect other parts of the code base, however.