### PR TITLE
Properly chain exception

### DIFF
--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -41,8 +41,8 @@ class AWSObject(object):
     def __getattr__(self, name):
         try:
             return self.properties.__getitem__(name)
-        except KeyError:
-            raise AttributeError(name)
+        except KeyError as exc:
+            raise AttributeError(name) from exc
 
     def __setattr__(self, name, value):
         if '_AWSObject__initialized' not in self.__dict__:


### PR DESCRIPTION
Previously you'd get the message "During handling of an exception
another exception occurred". Exception chaining properly presents the
exception.

See: https://stackoverflow.com/a/792163