### PR TITLE
Emit proper ARN's for regionless services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ before_install:
   - pip install --upgrade pip setuptools wheel
 
 install:
-  - pip install --upgrade pep8 pyflakes
+  - pip install --upgrade pycodestyle pyflakes
 
 before_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs awacs; fi
-  - pep8 --version
-  - pep8 .
+  - pycodestyle --version
+  - pycodestyle --show-source --show-pep8 .
   - pyflakes .
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test
+
+PYDIRS=setup.py awacs examples tests tools
+
+test:
+	pycodestyle ${PYDIRS}
+	pyflakes ${PYDIRS}
+	python setup.py test

--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -52,6 +52,10 @@ class BaseARN(AWSHelperFn):
         else:
             aws_partition = "aws"
 
+        regionless = ['iam', 's3']
+        if service in regionless:
+            region = ""
+
         self.data = "arn:%s:%s:%s:%s:%s" % (
             aws_partition, service, region, account, resource)
 

--- a/awacs/s3.py
+++ b/awacs/s3.py
@@ -20,6 +20,8 @@ class Action(BaseAction):
 class ARN(BaseARN):
     def __init__(self, resource='', region='', account=''):
         sup = super(ARN, self)
+        # account is empty for S3
+        account = ''
         sup.__init__(service=prefix, resource=resource, region=region,
                      account=account)
 

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,0 +1,21 @@
+import unittest
+
+from awacs.ec2 import ARN
+
+
+class TestARN(unittest.TestCase):
+    def test_aws(self):
+        arn = ARN("image/ami", "us-east-1", "account")
+        self.assertEqual(
+            arn.JSONrepr(), "arn:aws:ec2:us-east-1:account:image/ami")
+
+    def test_cn(self):
+        arn = ARN("image/ami", "cn-north-1", "account")
+        self.assertEqual(
+            arn.JSONrepr(), "arn:aws-cn:ec2:cn-north-1:account:image/ami")
+
+    def test_gov(self):
+        arn = ARN("image/ami", "us-gov-west-1", "account")
+        self.assertEqual(
+            arn.JSONrepr(),
+            "arn:aws-us-gov:ec2:us-gov-west-1:account:image/ami")

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,0 +1,17 @@
+import unittest
+
+from awacs.iam import ARN
+
+
+class TestARN(unittest.TestCase):
+    def test_aws(self):
+        arn = ARN("root", "us-east-1", "account")
+        self.assertEqual(arn.JSONrepr(), "arn:aws:iam::account:root")
+
+    def test_cn(self):
+        arn = ARN("root", "cn-north-1", "account")
+        self.assertEqual(arn.JSONrepr(), "arn:aws-cn:iam::account:root")
+
+    def test_gov(self):
+        arn = ARN("root", "us-gov-west-1", "account")
+        self.assertEqual(arn.JSONrepr(), "arn:aws-us-gov:iam::account:root")

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,17 @@
+import unittest
+
+from awacs.s3 import ARN
+
+
+class TestARN(unittest.TestCase):
+    def test_aws(self):
+        arn = ARN("bucket/key", "us-east-1", "account")
+        self.assertEqual(arn.JSONrepr(), "arn:aws:s3:::bucket/key")
+
+    def test_cn(self):
+        arn = ARN("bucket/key", "cn-north-1", "account")
+        self.assertEqual(arn.JSONrepr(), "arn:aws-cn:s3:::bucket/key")
+
+    def test_gov(self):
+        arn = ARN("bucket/key", "us-gov-west-1", "account")
+        self.assertEqual(arn.JSONrepr(), "arn:aws-us-gov:s3:::bucket/key")


### PR DESCRIPTION
Some services like IAM and S3 do not include region information. This is implemented to ensure the right AWS partition is used based on the region.