### PR TITLE
Remove s3:ListObjects action (not present in IAM)

### DIFF
--- a/awacs/s3.py
+++ b/awacs/s3.py
@@ -75,7 +75,6 @@ ListBucketByTags = Action('ListBucketByTags')
 ListBucketMultipartUploads = Action('ListBucketMultipartUploads')
 ListBucketVersions = Action('ListBucketVersions')
 ListMultipartUploadParts = Action('ListMultipartUploadParts')
-ListObjects = Action('ListObjects')
 ObjectOwnerOverrideToBucketOwner = \
     Action('ObjectOwnerOverrideToBucketOwner')
 PutAccelerateConfiguration = Action('PutAccelerateConfiguration')


### PR DESCRIPTION
There doesn't seem to be an s3:ListObjects action in IAM -- the IAM action for the ListObjects and ListObjectsV2 API calls is s3:ListBucket.

https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html