### PR TITLE
add secrets manager 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ nosetests.xml
 
 # Ignore vim swap files
 .*.sw*
+
+# Ignore intellij
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ an AWS resource and auto-generate new files.
 The following commands can be run to update the repo:
 
 .. code-block:: sh
-
+  % pip install -r tools/requirements.txt
   % rm -rf generated/
   % python tools/gen.py
   % diff -u awacs generated

--- a/awacs/aws_marketplace.py
+++ b/awacs/aws_marketplace.py
@@ -6,7 +6,7 @@
 from aws import Action as BaseAction
 from aws import BaseARN
 
-service_name = 'AWS Marketplace Metering Service'
+service_name = 'AWS Marketplace'
 prefix = 'aws-marketplace'
 
 
@@ -23,9 +23,9 @@ class ARN(BaseARN):
                      account=account)
 
 
-BatchMeterUsage = Action('BatchMeterUsage')
-MeterUsage = Action('MeterUsage')
-ResolveCustomer = Action('ResolveCustomer')
 Subscribe = Action('Subscribe')
 Unsubscribe = Action('Unsubscribe')
 ViewSubscriptions = Action('ViewSubscriptions')
+BatchMeterUsage = Action('BatchMeterUsage')
+MeterUsage = Action('MeterUsage')
+ResolveCustomer = Action('ResolveCustomer')

--- a/awacs/secretsmanager.py
+++ b/awacs/secretsmanager.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2012-2013, Mark Peek <mark@peek.org>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from aws import Action as BaseAction
+from aws import BaseARN
+
+service_name = 'AWS Secrets Manager'
+prefix = 'secretsmanager'
+
+
+class Action(BaseAction):
+    def __init__(self, action=None):
+        sup = super(Action, self)
+        sup.__init__(prefix, action)
+
+
+class ARN(BaseARN):
+    def __init__(self, resource='', region='', account=''):
+        sup = super(ARN, self)
+        sup.__init__(service=prefix, resource=resource, region=region,
+                     account=account)
+
+
+CancelRotateSecret = Action('CancelRotateSecret')
+CreateSecret = Action('CreateSecret')
+DeleteResourcePolicy = Action('DeleteResourcePolicy')
+DeleteSecret = Action('DeleteSecret')
+DescribeSecret = Action('DescribeSecret')
+GetRandomPassword = Action('GetRandomPassword')
+GetResourcePolicy = Action('GetResourcePolicy')
+GetSecretValue = Action('GetSecretValue')
+ListSecretVersionIds = Action('ListSecretVersionIds')
+ListSecrets = Action('ListSecrets')
+PutResourcePolicy = Action('PutResourcePolicy')
+PutSecretValue = Action('PutSecretValue')
+RestoreSecret = Action('RestoreSecret')
+RotateSecre = Action('RotateSecre')
+TagResource = Action('TagResource')
+UntagResource = Action('UntagResource')
+UpdateSecret = Action('UpdateSecret')
+UpdateSecretVersionStage = Action('UpdateSecretVersionStage')

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -110,9 +110,11 @@ except OSError:
     pass
 
 
-# Extra services are for those not advertised in policies.js, but are available to be called via AWS apis.
-# If/When these services are added to policies.js, these entries will be ignored.
-# IE, policies.js take priority over the entries here.
+# Extra services are for those not advertised in policies.js,
+# but are available to be called via AWS apis. If/When these
+# services are added to policies.js, the entry in extra_services
+# will be ignored. IE, policies.js takes priority over
+# extra_services entries.
 
 extra_services = {
     'SMM Messages': {

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -219,8 +219,21 @@ missing_services = {
             'TagResource', 'UntagResource', 'UpdateSecret',
             'UpdateSecretVersionStage'
         ],
-        'HasResource': '1',
-        'StringPrefix': 'secretsmanager'
+        'HasResource': '!0',
+        'StringPrefix': 'secretsmanager',
+        'conditionKeys': [
+            'secretsmanager:Resource/AllowRotationLambdaArn',
+            'secretsmanager:Description',
+            'secretsmanager:ForceDeleteWithoutRecovery',
+            'secretsmanager:KmsKeyId',
+            'secretsmanager:Name',
+            'secretsmanager:RecoveryWindowInDays',
+            'secretsmanager:ResourceTag/<tagname>',
+            'secretsmanager:RotationLambdaArn',
+            'secretsmanager:SecretId',
+            'secretsmanager:VersionId',
+            'secretsmanager:VersionStage'
+        ]
     }
 }
 

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/rspivak/slimit.git#egg=slimit


### PR DESCRIPTION
Adds secrets manager to awacs, which is for some reason not advertised.

Permission reference for secrets manager is available here:
https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_iam-permissions.html