### PR TITLE
Add actions for EKS

### DIFF
--- a/awacs/eks.py
+++ b/awacs/eks.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2012-2013, Mark Peek <mark@peek.org>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from aws import Action as BaseAction
+from aws import BaseARN
+
+service_name = 'Amazon Elastic Container Service for Kubernetes'
+prefix = 'eks'
+
+
+class Action(BaseAction):
+    def __init__(self, action=None):
+        sup = super(Action, self)
+        sup.__init__(prefix, action)
+
+
+class ARN(BaseARN):
+    def __init__(self, resource='', region='', account=''):
+        sup = super(ARN, self)
+        sup.__init__(service=prefix, resource=resource, region=region,
+                     account=account)
+
+
+CreateCluster = Action('CreateCluster')
+DeleteCluster = Action('DeleteCluster')
+DescribeCluster = Action('DescribeCluster')
+DescribeUpdate = Action('DescribeUpdate')
+ListClusters = Action('ListClusters')
+ListUpdates = Action('ListUpdates')
+UpdateClusterVersion = Action('UpdateClusterVersion')

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -167,6 +167,14 @@ extra_services = {
             'SearchDirectoryGroups', 'SetGroupMapping', 'Subscribe',
             'Unsubscribe', 'UpdateGroup'
         ]
+    },
+    'Amazon Elastic Container Service for Kubernetes': {
+        'StringPrefix': 'eks',
+        'Actions': [
+            'CreateCluster', 'DeleteCluster', 'DescribeCluster',
+            'DescribeUpdate', 'ListClusters', 'ListUpdates',
+            'UpdateClusterVersion'
+        ]
     }
 }
 


### PR DESCRIPTION
Add actions for Amazon Elastic Container Service for Kubernetes (EKS) as described in https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonelasticcontainerserviceforkubernetes.html.

The service actions aren't described in `policies.js`.