### PR TITLE
Bugfix cognito_idp deleted actions, and add 'ManageConnections' to execute_api:

### DIFF
--- a/awacs/execute_api.py
+++ b/awacs/execute_api.py
@@ -25,3 +25,4 @@ class ARN(BaseARN):
 
 InvalidateCache = Action('InvalidateCache')
 Invoke = Action('Invoke')
+ManageConnections = Action('ManageConnections')

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -910,7 +910,11 @@ extra_services = {
     },
 }
 
-
+# Extra actions are for services that are advertised in the policies.js,
+# but have one or more individual actions that are missing. Actions specified here will be patched
+# with the advertised ones, creating a union of both.
+# Actions should be added alphabetically under their appropriate awacs prefix.
+# Note: If the prefix contains a '-' (dash) character, replace it with an '_' (underscore).
 extra_actions = {
     'a4b': [
         'ApproveSkill',
@@ -1178,8 +1182,6 @@ extra_actions = {
         'ListIdentityProviders',
         'ListResourceServers',
         'ListTagsForResource',
-        'ListUserPools',
-        'ListUsers',
         'SetUICustomization',
         'TagResource',
         'UntagResource',
@@ -1481,6 +1483,9 @@ extra_actions = {
         'RemovePermission',
         'TagResource',
         'UntagResource',
+    ],
+    'execute_api': [
+        'ManageConnections',
     ],
     'firehose': [
         'ListTagsForDeliveryStream', 'StartDeliveryStreamEncryption',
@@ -2013,12 +2018,13 @@ extra_actions = {
 
 # Some actions appear to be deleted but still in the docs. This grouping
 # will keep them available as it gets sorted out.
-
+# Actions should be added alphabetically under their appropriate awacs prefix.
+# Note: If the prefix contains a '-' (dash) character, replace it with an '_' (underscore).
 deleted_actions = {
     'cloudsearch': [
         'DefineIndexFields',
     ],
-    'cognito-idp': [
+    'cognito_idp': [
         'ListUserPools', 'ListUsers',
     ],
     'dax': [
@@ -2116,6 +2122,13 @@ for serviceName, serviceValue in d['serviceMap'].items():
                     'upper': prefix.upper(),
                 })
                 fp.write("\n\n")
+
+        # Make sure there are no actions in both the extra_actions and deleted_actions
+        if service in extra_actions and service in deleted_actions:
+            intersection = set(extra_actions[service]) & set(deleted_actions[service])
+            if intersection:
+                raise RuntimeError('Actions found that appear in both `extra_actions` and `deleted_actions` '
+                                   'for the aws service `{}`: {}'.format(service, intersection))
 
         # Add actions AWS hasn't added yet
         if service in extra_actions:

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -910,11 +910,12 @@ extra_services = {
     },
 }
 
-# Extra actions are for services that are advertised in the policies.js,
-# but have one or more individual actions that are missing. Actions specified here will be patched
-# with the advertised ones, creating a union of both.
+# Extra actions are for services that are advertised in the policies.js, but
+# have one or more individual actions that are missing. Actions specified here
+# will be patched with the advertised ones, creating a union of both.
 # Actions should be added alphabetically under their appropriate awacs prefix.
-# Note: If the prefix contains a '-' (dash) character, replace it with an '_' (underscore).
+# Note: If the prefix contains a '-' (dash) character, replace it with
+# an '_' (underscore).
 extra_actions = {
     'a4b': [
         'ApproveSkill',
@@ -2019,7 +2020,8 @@ extra_actions = {
 # Some actions appear to be deleted but still in the docs. This grouping
 # will keep them available as it gets sorted out.
 # Actions should be added alphabetically under their appropriate awacs prefix.
-# Note: If the prefix contains a '-' (dash) character, replace it with an '_' (underscore).
+# Note: If the prefix contains a '-' (dash) character, replace it with
+# an '_' (underscore).
 deleted_actions = {
     'cloudsearch': [
         'DefineIndexFields',
@@ -2123,12 +2125,16 @@ for serviceName, serviceValue in d['serviceMap'].items():
                 })
                 fp.write("\n\n")
 
-        # Make sure there are no actions in both the extra_actions and deleted_actions
+        # Make sure there are no actions in both the extra_actions
+        # and deleted_actions.
         if service in extra_actions and service in deleted_actions:
-            intersection = set(extra_actions[service]) & set(deleted_actions[service])
+            intersection = set(extra_actions[service]) & \
+                           set(deleted_actions[service])
             if intersection:
-                raise RuntimeError('Actions found that appear in both `extra_actions` and `deleted_actions` '
-                                   'for the aws service `{}`: {}'.format(service, intersection))
+                raise RuntimeError('Actions found that appear in both '
+                                   '`extra_actions` and `deleted_actions` '
+                                   'for the aws service `{}`: {}'.format(
+                                        service, intersection))
 
         # Add actions AWS hasn't added yet
         if service in extra_actions:


### PR DESCRIPTION
Summary:
* Fix deleted_actions cognito-idp to cognito_idp
* Added comments for contributors, around using underscores for prefix names
* Add a guardian so if an action is in deleted_actions and extra_actions, a runtime error is thrown
* Resolve the conflict in cognito_idp by using commit dates (removed the older ones in extra_actions)
* Add "ManageConnections" to execute_api, screen shot attached:
![Screen Shot 2019-06-06 at 8 35 47 AM](https://user-images.githubusercontent.com/4174972/59041039-793e0100-883d-11e9-9a3e-19de1a1e012f.png)
