### PR TITLE
change isinstance AWSHelperFn to inspect class names

### DIFF
--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-
+import inspect
 import json
 import re
 import types
@@ -72,9 +72,12 @@ class AWSObject(object):
                 return self.properties.__setitem__(name, value)
 
             # Single type so check the type of the object and compare against
-            # what we were expecting. Special case AWS helper functions.
+            # what we were expecting. Special case AWS helper functions and its
+            # sub classes. Also handles AWS helper functions from other
+            # libraries like cloudtools/troposphere.
             elif isinstance(value, expected_type) or \
-                    isinstance(value, AWSHelperFn):
+                    'AWSHelperFn' in [c.__name__
+                                      for c in inspect.getmro(type(value))]:
                 return self.properties.__setitem__(name, value)
             else:
                 self._raise_type(name, value, expected_type)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,44 @@
+import json
 import unittest
 
-from awacs.aws import PolicyDocument
+import awacs
+from awacs.aws import Action, PolicyDocument
+
+
+class AWSHelperFn(object):
+    """Mock class to test classes with non-awacs AWSHelperFn parent."""
+
+    def to_json(self, indent=4, sort_keys=True):
+        p = self
+        return json.dumps(p, cls=awacs.awsencode, indent=indent,
+                          sort_keys=sort_keys)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.to_json() == other.to_json()
+        else:
+            return False
+
+
+class AWSHelperFnChild(AWSHelperFn):
+    """Child class of non-awacs AWSHelperFn."""
+
+    def __init__(self, **kwargs):
+        """Instantiate class."""
+        for key, val in kwargs.items():
+            setattr(self, key, val)
+
+    def JSONrepr(self):
+        """JSON serialization."""
+        return self.__dict__
+
+
+class TypeValidationObject(awacs.AWSProperty):
+    """Subclass the AWSObject to test its functionality."""
+
+    props = {
+        'ExpectList': (list, False)
+    }
 
 
 class TestAWSObject(unittest.TestCase):
@@ -14,3 +52,36 @@ class TestAWSObject(unittest.TestCase):
             "'awacs.aws.PolicyDocument' object does not support attribute "
             "'statement'"
         )
+
+
+class TestAWSProperty(unittest.TestCase):
+    def test_prop_value_type_mismatch_expect_list(self):
+        class InvalidClass(object):
+            """Class of invalid type."""
+
+        tests_values = [
+            'val',
+            {'key': 'val'},
+            {'val'},
+            tuple('val'),
+            InvalidClass()
+        ]
+
+        for val in tests_values:
+            with self.assertRaises(TypeError) as exc:
+                TypeValidationObject(ExpectList=val)
+            self.assertEqual(
+                exc.exception.args[0],
+                "ExpectList is %s, expected <type 'list'>" % type(val)
+            )
+
+    def test_prop_value_type_expect_list(self):
+        tests_values = [
+            ['val'],
+            Action('s3', '*'),
+            AWSHelperFnChild(key='val')
+        ]
+
+        for val in tests_values:
+            self.assertEqual(TypeValidationObject(ExpectList=val).ExpectList,
+                             val)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -72,7 +72,7 @@ class TestAWSProperty(unittest.TestCase):
                 TypeValidationObject(ExpectList=val)
             self.assertEqual(
                 exc.exception.args[0],
-                "ExpectList is %s, expected <type 'list'>" % type(val)
+                "ExpectList is %s, expected %s" % (type(val), type(list()))
             )
 
     def test_prop_value_type_expect_list(self):


### PR DESCRIPTION
This will allow for the internal `awacs.AWSHelperFn` class + subclasses and `troposphere.AWSHelperFn` class + subclasses to be used as a value for all properties enabling the use of `troposphere.Ref` or similar to be used.

Resolves #139.