### PR TITLE
Changes for Python 3.6+ (deprecating Python 2.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 dist: xenial
 python:
-  - "2.7"
   - "3.6"
   - "3.7.3"
   - "3.8"
+  - "3.9"
 
 before_install:
   - pip install --upgrade pip setuptools wheel
@@ -13,7 +13,6 @@ install:
   - pip install --upgrade pycodestyle pyflakes
 
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs awacs; else rm -rf ./scrape; fi
   - pycodestyle --version
   - pycodestyle --show-source --show-pep8 .
   - pyflakes .

--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -13,12 +13,12 @@ __version__ = "1.0.4"
 valid_names = re.compile(r'^[a-zA-Z0-9]+$')
 
 
-class AWSObject(object):
+class AWSObject:
     def __init__(self, name, type=None, dictname=None, props={}, **kwargs):
         self.name = name
         self.props = props
         # Cache the keys for validity checks
-        self.propnames = list(props.keys())
+        self.propnames = props.keys()
 
         # unset/None is also legal
         if name and not valid_names.match(name):
@@ -131,7 +131,7 @@ class AWSProperty(AWSObject):
         sup.__init__(None, props=self.props, **kwargs)
 
 
-class AWSHelperFn(object):
+class AWSHelperFn:
     def getdata(self, data):
         if isinstance(data, AWSObject):
             return data.name

--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -18,7 +18,7 @@ class AWSObject(object):
         self.name = name
         self.props = props
         # Cache the keys for validity checks
-        self.propnames = props.keys()
+        self.propnames = list(props.keys())
 
         # unset/None is also legal
         if name and not valid_names.match(name):

--- a/awacs/a4b.py
+++ b/awacs/a4b.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Alexa for Business'
 prefix = 'a4b'

--- a/awacs/access_analyzer.py
+++ b/awacs/access_analyzer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IAM Access Analyzer'
 prefix = 'access-analyzer'

--- a/awacs/account.py
+++ b/awacs/account.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Accounts'
 prefix = 'account'

--- a/awacs/acm.py
+++ b/awacs/acm.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Certificate Manager'
 prefix = 'acm'

--- a/awacs/acm_pca.py
+++ b/awacs/acm_pca.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Certificate Manager Private Certificate Authority'
 prefix = 'acm-pca'

--- a/awacs/activate.py
+++ b/awacs/activate.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Activate'
 prefix = 'activate'

--- a/awacs/airflow.py
+++ b/awacs/airflow.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Managed Workflows for Apache Airflow'
 prefix = 'airflow'

--- a/awacs/amplify.py
+++ b/awacs/amplify.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Amplify'
 prefix = 'amplify'

--- a/awacs/amplifybackend.py
+++ b/awacs/amplifybackend.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Amplify Admin'
 prefix = 'amplifybackend'

--- a/awacs/apigateway.py
+++ b/awacs/apigateway.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Manage Amazon API Gateway'
 prefix = 'apigateway'

--- a/awacs/app_integrations.py
+++ b/awacs/app_integrations.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon AppIntegrations'
 prefix = 'app-integrations'

--- a/awacs/appconfig.py
+++ b/awacs/appconfig.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS AppConfig'
 prefix = 'appconfig'

--- a/awacs/appflow.py
+++ b/awacs/appflow.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon AppFlow'
 prefix = 'appflow'

--- a/awacs/application_autoscaling.py
+++ b/awacs/application_autoscaling.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Application Auto Scaling'
 prefix = 'application-autoscaling'

--- a/awacs/applicationinsights.py
+++ b/awacs/applicationinsights.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'CloudWatch Application Insights'
 prefix = 'applicationinsights'

--- a/awacs/appmesh.py
+++ b/awacs/appmesh.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS App Mesh'
 prefix = 'appmesh'

--- a/awacs/appmesh_preview.py
+++ b/awacs/appmesh_preview.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS App Mesh Preview'
 prefix = 'appmesh-preview'

--- a/awacs/appstream.py
+++ b/awacs/appstream.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon AppStream 2.0'
 prefix = 'appstream'

--- a/awacs/appsync.py
+++ b/awacs/appsync.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS AppSync'
 prefix = 'appsync'

--- a/awacs/aps.py
+++ b/awacs/aps.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Managed Service for Prometheus'
 prefix = 'aps'

--- a/awacs/arsenal.py
+++ b/awacs/arsenal.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Application Discovery Arsenal'
 prefix = 'arsenal'

--- a/awacs/artifact.py
+++ b/awacs/artifact.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Artifact'
 prefix = 'artifact'

--- a/awacs/athena.py
+++ b/awacs/athena.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Athena'
 prefix = 'athena'

--- a/awacs/auditmanager.py
+++ b/awacs/auditmanager.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Audit Manager'
 prefix = 'auditmanager'

--- a/awacs/autoscaling.py
+++ b/awacs/autoscaling.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon EC2 Auto Scaling'
 prefix = 'autoscaling'

--- a/awacs/autoscaling_plans.py
+++ b/awacs/autoscaling_plans.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Auto Scaling'
 prefix = 'autoscaling-plans'

--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -172,15 +172,15 @@ class Statement(AWSProperty):
         'Principal': (Principal, False),
         'Resource': (list, False),
         'NotResource': (list, False),
-        'Sid': (basestring, False),
+        'Sid': (str, False),
     }
 
 
 class Policy(AWSProperty):
     props = {
-        'Id': (basestring, False),
+        'Id': (str, False),
         'Statement': ([Statement], True),
-        'Version': (basestring, False),
+        'Version': (str, False),
     }
 
     def JSONrepr(self):

--- a/awacs/aws_marketplace.py
+++ b/awacs/aws_marketplace.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Marketplace'
 prefix = 'aws-marketplace'

--- a/awacs/aws_marketplace_management.py
+++ b/awacs/aws_marketplace_management.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Marketplace Management Portal'
 prefix = 'aws-marketplace-management'

--- a/awacs/aws_portal.py
+++ b/awacs/aws_portal.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Billing'
 prefix = 'aws-portal'

--- a/awacs/awsconnector.py
+++ b/awacs/awsconnector.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Connector Service'
 prefix = 'awsconnector'

--- a/awacs/awslambda.py
+++ b/awacs/awslambda.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Lambda'
 prefix = 'lambda'

--- a/awacs/backup.py
+++ b/awacs/backup.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Backup'
 prefix = 'backup'

--- a/awacs/backup_storage.py
+++ b/awacs/backup_storage.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Backup storage'
 prefix = 'backup-storage'

--- a/awacs/batch.py
+++ b/awacs/batch.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Batch'
 prefix = 'batch'

--- a/awacs/braket.py
+++ b/awacs/braket.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Braket'
 prefix = 'braket'

--- a/awacs/budgets.py
+++ b/awacs/budgets.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Budget Service'
 prefix = 'budgets'

--- a/awacs/cassandra.py
+++ b/awacs/cassandra.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Keyspaces (for Apache Cassandra)'
 prefix = 'cassandra'

--- a/awacs/ce.py
+++ b/awacs/ce.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Cost Explorer Service'
 prefix = 'ce'

--- a/awacs/chatbot.py
+++ b/awacs/chatbot.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Chatbot'
 prefix = 'chatbot'

--- a/awacs/chime.py
+++ b/awacs/chime.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Chime'
 prefix = 'chime'

--- a/awacs/cloud9.py
+++ b/awacs/cloud9.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Cloud9'
 prefix = 'cloud9'

--- a/awacs/clouddirectory.py
+++ b/awacs/clouddirectory.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Cloud Directory'
 prefix = 'clouddirectory'

--- a/awacs/cloudformation.py
+++ b/awacs/cloudformation.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CloudFormation'
 prefix = 'cloudformation'

--- a/awacs/cloudfront.py
+++ b/awacs/cloudfront.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CloudFront'
 prefix = 'cloudfront'

--- a/awacs/cloudhsm.py
+++ b/awacs/cloudhsm.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CloudHSM'
 prefix = 'cloudhsm'

--- a/awacs/cloudsearch.py
+++ b/awacs/cloudsearch.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CloudSearch'
 prefix = 'cloudsearch'

--- a/awacs/cloudshell.py
+++ b/awacs/cloudshell.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CloudShell'
 prefix = 'cloudshell'

--- a/awacs/cloudtrail.py
+++ b/awacs/cloudtrail.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CloudTrail'
 prefix = 'cloudtrail'

--- a/awacs/cloudwatch.py
+++ b/awacs/cloudwatch.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CloudWatch'
 prefix = 'cloudwatch'

--- a/awacs/codeartifact.py
+++ b/awacs/codeartifact.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodeArtifact'
 prefix = 'codeartifact'

--- a/awacs/codebuild.py
+++ b/awacs/codebuild.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodeBuild'
 prefix = 'codebuild'

--- a/awacs/codecommit.py
+++ b/awacs/codecommit.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodeCommit'
 prefix = 'codecommit'

--- a/awacs/codedeploy.py
+++ b/awacs/codedeploy.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodeDeploy'
 prefix = 'codedeploy'

--- a/awacs/codeguru.py
+++ b/awacs/codeguru.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CodeGuru'
 prefix = 'codeguru'

--- a/awacs/codeguru_profiler.py
+++ b/awacs/codeguru_profiler.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CodeGuru Profiler'
 prefix = 'codeguru-profiler'

--- a/awacs/codeguru_reviewer.py
+++ b/awacs/codeguru_reviewer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CodeGuru Reviewer'
 prefix = 'codeguru-reviewer'

--- a/awacs/codepipeline.py
+++ b/awacs/codepipeline.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodePipeline'
 prefix = 'codepipeline'

--- a/awacs/codestar.py
+++ b/awacs/codestar.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodeStar'
 prefix = 'codestar'

--- a/awacs/codestar_connections.py
+++ b/awacs/codestar_connections.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodeStar Connections'
 prefix = 'codestar-connections'

--- a/awacs/codestar_notifications.py
+++ b/awacs/codestar_notifications.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS CodeStar Notifications'
 prefix = 'codestar-notifications'

--- a/awacs/cognito_identity.py
+++ b/awacs/cognito_identity.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Cognito Identity'
 prefix = 'cognito-identity'

--- a/awacs/cognito_idp.py
+++ b/awacs/cognito_idp.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Cognito User Pools'
 prefix = 'cognito-idp'

--- a/awacs/cognito_sync.py
+++ b/awacs/cognito_sync.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Cognito Sync'
 prefix = 'cognito-sync'

--- a/awacs/comprehend.py
+++ b/awacs/comprehend.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Comprehend'
 prefix = 'comprehend'

--- a/awacs/comprehendmedical.py
+++ b/awacs/comprehendmedical.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Comprehend Medical'
 prefix = 'comprehendmedical'

--- a/awacs/compute_optimizer.py
+++ b/awacs/compute_optimizer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Compute Optimizer'
 prefix = 'compute-optimizer'

--- a/awacs/config.py
+++ b/awacs/config.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Config'
 prefix = 'config'

--- a/awacs/connect.py
+++ b/awacs/connect.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Connect'
 prefix = 'connect'

--- a/awacs/cur.py
+++ b/awacs/cur.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Cost and Usage Report'
 prefix = 'cur'

--- a/awacs/databrew.py
+++ b/awacs/databrew.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Glue DataBrew'
 prefix = 'databrew'

--- a/awacs/dataexchange.py
+++ b/awacs/dataexchange.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Data Exchange'
 prefix = 'dataexchange'

--- a/awacs/datapipeline.py
+++ b/awacs/datapipeline.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Data Pipeline'
 prefix = 'datapipeline'

--- a/awacs/datasync.py
+++ b/awacs/datasync.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWSDataSync'
 prefix = 'datasync'

--- a/awacs/dax.py
+++ b/awacs/dax.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon DynamoDB Accelerator (DAX)'
 prefix = 'dax'

--- a/awacs/dbqms.py
+++ b/awacs/dbqms.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Database Query Metadata Service'
 prefix = 'dbqms'

--- a/awacs/deepcomposer.py
+++ b/awacs/deepcomposer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS DeepComposer'
 prefix = 'deepcomposer'

--- a/awacs/deeplens.py
+++ b/awacs/deeplens.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS DeepLens'
 prefix = 'deeplens'

--- a/awacs/deepracer.py
+++ b/awacs/deepracer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS DeepRacer'
 prefix = 'deepracer'

--- a/awacs/detective.py
+++ b/awacs/detective.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Detective'
 prefix = 'detective'

--- a/awacs/devicefarm.py
+++ b/awacs/devicefarm.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Device Farm'
 prefix = 'devicefarm'

--- a/awacs/devops_guru.py
+++ b/awacs/devops_guru.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon DevOps Guru'
 prefix = 'devops-guru'

--- a/awacs/directconnect.py
+++ b/awacs/directconnect.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Direct Connect'
 prefix = 'directconnect'

--- a/awacs/discovery.py
+++ b/awacs/discovery.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Application Discovery'
 prefix = 'discovery'

--- a/awacs/dlm.py
+++ b/awacs/dlm.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Data Lifecycle Manager'
 prefix = 'dlm'

--- a/awacs/dms.py
+++ b/awacs/dms.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Database Migration Service'
 prefix = 'dms'

--- a/awacs/ds.py
+++ b/awacs/ds.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Directory Service'
 prefix = 'ds'

--- a/awacs/dynamodb.py
+++ b/awacs/dynamodb.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon DynamoDB'
 prefix = 'dynamodb'

--- a/awacs/ebs.py
+++ b/awacs/ebs.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic Block Store'
 prefix = 'ebs'

--- a/awacs/ec2.py
+++ b/awacs/ec2.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon EC2'
 prefix = 'ec2'

--- a/awacs/ec2_instance_connect.py
+++ b/awacs/ec2_instance_connect.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon EC2 Instance Connect'
 prefix = 'ec2-instance-connect'

--- a/awacs/ec2messages.py
+++ b/awacs/ec2messages.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Message Delivery Service'
 prefix = 'ec2messages'

--- a/awacs/ecr.py
+++ b/awacs/ecr.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic Container Registry'
 prefix = 'ecr'

--- a/awacs/ecr_public.py
+++ b/awacs/ecr_public.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic Container Registry Public'
 prefix = 'ecr-public'

--- a/awacs/ecs.py
+++ b/awacs/ecs.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic Container Service'
 prefix = 'ecs'

--- a/awacs/eks.py
+++ b/awacs/eks.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic Kubernetes Service'
 prefix = 'eks'

--- a/awacs/elastic_inference.py
+++ b/awacs/elastic_inference.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic Inference'
 prefix = 'elastic-inference'

--- a/awacs/elasticache.py
+++ b/awacs/elasticache.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon ElastiCache'
 prefix = 'elasticache'

--- a/awacs/elasticbeanstalk.py
+++ b/awacs/elasticbeanstalk.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elastic Beanstalk'
 prefix = 'elasticbeanstalk'

--- a/awacs/elasticfilesystem.py
+++ b/awacs/elasticfilesystem.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic File System'
 prefix = 'elasticfilesystem'

--- a/awacs/elasticloadbalancing.py
+++ b/awacs/elasticloadbalancing.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Elastic Load Balancing'
 prefix = 'elasticloadbalancing'

--- a/awacs/elasticmapreduce.py
+++ b/awacs/elasticmapreduce.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic MapReduce'
 prefix = 'elasticmapreduce'

--- a/awacs/elastictranscoder.py
+++ b/awacs/elastictranscoder.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elastic Transcoder'
 prefix = 'elastictranscoder'

--- a/awacs/elemental_activations.py
+++ b/awacs/elemental_activations.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental Appliances and Software Activation Service'
 prefix = 'elemental-activations'

--- a/awacs/elemental_appliances_software.py
+++ b/awacs/elemental_appliances_software.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental Appliances and Software'
 prefix = 'elemental-appliances-software'

--- a/awacs/elemental_support_cases.py
+++ b/awacs/elemental_support_cases.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Elemental Support Cases'
 prefix = 'elemental-support-cases'

--- a/awacs/elemental_support_content.py
+++ b/awacs/elemental_support_content.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Elemental Support Content'
 prefix = 'elemental-support-content'

--- a/awacs/emr_containers.py
+++ b/awacs/emr_containers.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon EMR on EKS (EMR Containers)'
 prefix = 'emr-containers'

--- a/awacs/es.py
+++ b/awacs/es.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Elasticsearch Service'
 prefix = 'es'

--- a/awacs/events.py
+++ b/awacs/events.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon EventBridge'
 prefix = 'events'

--- a/awacs/execute_api.py
+++ b/awacs/execute_api.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon API Gateway'
 prefix = 'execute-api'

--- a/awacs/firehose.py
+++ b/awacs/firehose.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Kinesis Firehose'
 prefix = 'firehose'

--- a/awacs/fis.py
+++ b/awacs/fis.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Fault Injection Simulator'
 prefix = 'fis'

--- a/awacs/fms.py
+++ b/awacs/fms.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Firewall Manager'
 prefix = 'fms'

--- a/awacs/forecast.py
+++ b/awacs/forecast.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Forecast'
 prefix = 'forecast'

--- a/awacs/frauddetector.py
+++ b/awacs/frauddetector.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Fraud Detector'
 prefix = 'frauddetector'

--- a/awacs/freertos.py
+++ b/awacs/freertos.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon FreeRTOS'
 prefix = 'freertos'

--- a/awacs/fsx.py
+++ b/awacs/fsx.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon FSx'
 prefix = 'fsx'

--- a/awacs/gamelift.py
+++ b/awacs/gamelift.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon GameLift'
 prefix = 'gamelift'

--- a/awacs/geo.py
+++ b/awacs/geo.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Location'
 prefix = 'geo'

--- a/awacs/glacier.py
+++ b/awacs/glacier.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Glacier'
 prefix = 'glacier'

--- a/awacs/globalaccelerator.py
+++ b/awacs/globalaccelerator.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Global Accelerator'
 prefix = 'globalaccelerator'

--- a/awacs/glue.py
+++ b/awacs/glue.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Glue'
 prefix = 'glue'

--- a/awacs/grafana.py
+++ b/awacs/grafana.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Managed Service for Grafana'
 prefix = 'grafana'

--- a/awacs/greengrass.py
+++ b/awacs/greengrass.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT Greengrass'
 prefix = 'greengrass'

--- a/awacs/groundstation.py
+++ b/awacs/groundstation.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Ground Station'
 prefix = 'groundstation'

--- a/awacs/groundtruthlabeling.py
+++ b/awacs/groundtruthlabeling.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon GroundTruth Labeling'
 prefix = 'groundtruthlabeling'

--- a/awacs/guardduty.py
+++ b/awacs/guardduty.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon GuardDuty'
 prefix = 'guardduty'

--- a/awacs/health.py
+++ b/awacs/health.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Health APIs and Notifications'
 prefix = 'health'

--- a/awacs/healthlake.py
+++ b/awacs/healthlake.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon HealthLake'
 prefix = 'healthlake'

--- a/awacs/honeycode.py
+++ b/awacs/honeycode.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Honeycode'
 prefix = 'honeycode'

--- a/awacs/iam.py
+++ b/awacs/iam.py
@@ -4,8 +4,8 @@ import warnings
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Identity And Access Management'
 prefix = 'iam'

--- a/awacs/identitystore.py
+++ b/awacs/identitystore.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Identity Store'
 prefix = 'identitystore'

--- a/awacs/imagebuilder.py
+++ b/awacs/imagebuilder.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon EC2 Image Builder'
 prefix = 'imagebuilder'

--- a/awacs/importexport.py
+++ b/awacs/importexport.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Import Export Disk Service'
 prefix = 'importexport'

--- a/awacs/inspector.py
+++ b/awacs/inspector.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Inspector'
 prefix = 'inspector'

--- a/awacs/iot.py
+++ b/awacs/iot.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT'
 prefix = 'iot'

--- a/awacs/iot1click.py
+++ b/awacs/iot1click.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT 1-Click'
 prefix = 'iot1click'

--- a/awacs/iot_device_tester.py
+++ b/awacs/iot_device_tester.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT Device Tester'
 prefix = 'iot-device-tester'

--- a/awacs/iotanalytics.py
+++ b/awacs/iotanalytics.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT Analytics'
 prefix = 'iotanalytics'

--- a/awacs/iotdeviceadvisor.py
+++ b/awacs/iotdeviceadvisor.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT Core Device Advisor'
 prefix = 'iotdeviceadvisor'

--- a/awacs/iotevents.py
+++ b/awacs/iotevents.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT Events'
 prefix = 'iotevents'

--- a/awacs/iotfleethub.py
+++ b/awacs/iotfleethub.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Fleet Hub for AWS IoT Device Management'
 prefix = 'iotfleethub'

--- a/awacs/iotsitewise.py
+++ b/awacs/iotsitewise.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT SiteWise'
 prefix = 'iotsitewise'

--- a/awacs/iotthingsgraph.py
+++ b/awacs/iotthingsgraph.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT Things Graph'
 prefix = 'iotthingsgraph'

--- a/awacs/iotwireless.py
+++ b/awacs/iotwireless.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IoT Core for LoRaWAN'
 prefix = 'iotwireless'

--- a/awacs/iq.py
+++ b/awacs/iq.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IQ'
 prefix = 'iq'

--- a/awacs/iq_permission.py
+++ b/awacs/iq_permission.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS IQ Permissions'
 prefix = 'iq-permission'

--- a/awacs/ivs.py
+++ b/awacs/ivs.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Interactive Video Service'
 prefix = 'ivs'

--- a/awacs/kafka.py
+++ b/awacs/kafka.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Managed Streaming for Apache Kafka'
 prefix = 'kafka'

--- a/awacs/kendra.py
+++ b/awacs/kendra.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Kendra'
 prefix = 'kendra'

--- a/awacs/kinesis.py
+++ b/awacs/kinesis.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Kinesis'
 prefix = 'kinesis'

--- a/awacs/kinesisanalytics.py
+++ b/awacs/kinesisanalytics.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Kinesis Analytics'
 prefix = 'kinesisanalytics'

--- a/awacs/kinesisvideo.py
+++ b/awacs/kinesisvideo.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Kinesis Video Streams'
 prefix = 'kinesisvideo'

--- a/awacs/kms.py
+++ b/awacs/kms.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Key Management Service'
 prefix = 'kms'

--- a/awacs/lakeformation.py
+++ b/awacs/lakeformation.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Lake Formation'
 prefix = 'lakeformation'

--- a/awacs/launchwizard.py
+++ b/awacs/launchwizard.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Launch Wizard'
 prefix = 'launchwizard'

--- a/awacs/lex.py
+++ b/awacs/lex.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Lex'
 prefix = 'lex'

--- a/awacs/license_manager.py
+++ b/awacs/license_manager.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS License Manager'
 prefix = 'license-manager'

--- a/awacs/lightsail.py
+++ b/awacs/lightsail.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Lightsail'
 prefix = 'lightsail'

--- a/awacs/logs.py
+++ b/awacs/logs.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CloudWatch Logs'
 prefix = 'logs'

--- a/awacs/lookoutequipment.py
+++ b/awacs/lookoutequipment.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Lookout for Equipment'
 prefix = 'lookoutequipment'

--- a/awacs/lookoutmetrics.py
+++ b/awacs/lookoutmetrics.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Lookout for Metrics'
 prefix = 'lookoutmetrics'

--- a/awacs/lookoutvision.py
+++ b/awacs/lookoutvision.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Lookout for Vision'
 prefix = 'lookoutvision'

--- a/awacs/machinelearning.py
+++ b/awacs/machinelearning.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Machine Learning'
 prefix = 'machinelearning'

--- a/awacs/macie.py
+++ b/awacs/macie.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Macie Classic'
 prefix = 'macie'

--- a/awacs/macie2.py
+++ b/awacs/macie2.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Macie'
 prefix = 'macie2'

--- a/awacs/managedblockchain.py
+++ b/awacs/managedblockchain.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Managed Blockchain'
 prefix = 'managedblockchain'

--- a/awacs/marketplacecommerceanalytics.py
+++ b/awacs/marketplacecommerceanalytics.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Marketplace Commerce Analytics Service'
 prefix = 'marketplacecommerceanalytics'

--- a/awacs/mechanicalturk.py
+++ b/awacs/mechanicalturk.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Mechanical Turk'
 prefix = 'mechanicalturk'

--- a/awacs/mediaconnect.py
+++ b/awacs/mediaconnect.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental MediaConnect'
 prefix = 'mediaconnect'

--- a/awacs/mediaconvert.py
+++ b/awacs/mediaconvert.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental MediaConvert'
 prefix = 'mediaconvert'

--- a/awacs/medialive.py
+++ b/awacs/medialive.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental MediaLive'
 prefix = 'medialive'

--- a/awacs/mediapackage.py
+++ b/awacs/mediapackage.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental MediaPackage'
 prefix = 'mediapackage'

--- a/awacs/mediapackage_vod.py
+++ b/awacs/mediapackage_vod.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental MediaPackage VOD'
 prefix = 'mediapackage-vod'

--- a/awacs/mediastore.py
+++ b/awacs/mediastore.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental MediaStore'
 prefix = 'mediastore'

--- a/awacs/mediatailor.py
+++ b/awacs/mediatailor.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Elemental MediaTailor'
 prefix = 'mediatailor'

--- a/awacs/mgh.py
+++ b/awacs/mgh.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Migration Hub'
 prefix = 'mgh'

--- a/awacs/mobileanalytics.py
+++ b/awacs/mobileanalytics.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Mobile Analytics'
 prefix = 'mobileanalytics'

--- a/awacs/mobilehub.py
+++ b/awacs/mobilehub.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Mobile Hub'
 prefix = 'mobilehub'

--- a/awacs/mobiletargeting.py
+++ b/awacs/mobiletargeting.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Pinpoint'
 prefix = 'mobiletargeting'

--- a/awacs/monitron.py
+++ b/awacs/monitron.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Monitron'
 prefix = 'monitron'

--- a/awacs/mq.py
+++ b/awacs/mq.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon MQ'
 prefix = 'mq'

--- a/awacs/neptune_db.py
+++ b/awacs/neptune_db.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Neptune'
 prefix = 'neptune-db'

--- a/awacs/network_firewall.py
+++ b/awacs/network_firewall.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Network Firewall'
 prefix = 'network-firewall'

--- a/awacs/networkmanager.py
+++ b/awacs/networkmanager.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Network Manager'
 prefix = 'networkmanager'

--- a/awacs/opsworks.py
+++ b/awacs/opsworks.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS OpsWorks'
 prefix = 'opsworks'

--- a/awacs/opsworks_cm.py
+++ b/awacs/opsworks_cm.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS OpsWorks Configuration Management'
 prefix = 'opsworks-cm'

--- a/awacs/organizations.py
+++ b/awacs/organizations.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Organizations'
 prefix = 'organizations'

--- a/awacs/outposts.py
+++ b/awacs/outposts.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Outposts'
 prefix = 'outposts'

--- a/awacs/panorama.py
+++ b/awacs/panorama.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Panorama'
 prefix = 'panorama'

--- a/awacs/personalize.py
+++ b/awacs/personalize.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Personalize'
 prefix = 'personalize'

--- a/awacs/pi.py
+++ b/awacs/pi.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Performance Insights'
 prefix = 'pi'

--- a/awacs/polly.py
+++ b/awacs/polly.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Polly'
 prefix = 'polly'

--- a/awacs/pricing.py
+++ b/awacs/pricing.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Price List'
 prefix = 'pricing'

--- a/awacs/profile.py
+++ b/awacs/profile.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Connect Customer Profiles'
 prefix = 'profile'

--- a/awacs/proton.py
+++ b/awacs/proton.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Proton'
 prefix = 'proton'

--- a/awacs/purchase_orders.py
+++ b/awacs/purchase_orders.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Purchase Orders Console'
 prefix = 'purchase-orders'

--- a/awacs/qldb.py
+++ b/awacs/qldb.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon QLDB'
 prefix = 'qldb'

--- a/awacs/quicksight.py
+++ b/awacs/quicksight.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon QuickSight'
 prefix = 'quicksight'

--- a/awacs/ram.py
+++ b/awacs/ram.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Resource Access Manager'
 prefix = 'ram'

--- a/awacs/rds.py
+++ b/awacs/rds.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon RDS'
 prefix = 'rds'

--- a/awacs/rds_data.py
+++ b/awacs/rds_data.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon RDS Data API'
 prefix = 'rds-data'

--- a/awacs/rds_db.py
+++ b/awacs/rds_db.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon RDS IAM Authentication'
 prefix = 'rds-db'

--- a/awacs/redshift.py
+++ b/awacs/redshift.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Redshift'
 prefix = 'redshift'

--- a/awacs/redshift_data.py
+++ b/awacs/redshift_data.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Redshift Data API'
 prefix = 'redshift-data'

--- a/awacs/rekognition.py
+++ b/awacs/rekognition.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Rekognition'
 prefix = 'rekognition'

--- a/awacs/resource_explorer.py
+++ b/awacs/resource_explorer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Tag Editor'
 prefix = 'resource-explorer'

--- a/awacs/resource_groups.py
+++ b/awacs/resource_groups.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Resource Groups'
 prefix = 'resource-groups'

--- a/awacs/robomaker.py
+++ b/awacs/robomaker.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS RoboMaker'
 prefix = 'robomaker'

--- a/awacs/route53.py
+++ b/awacs/route53.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Route 53'
 prefix = 'route53'

--- a/awacs/route53domains.py
+++ b/awacs/route53domains.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Route53 Domains'
 prefix = 'route53domains'

--- a/awacs/route53resolver.py
+++ b/awacs/route53resolver.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Route 53 Resolver'
 prefix = 'route53resolver'

--- a/awacs/s3.py
+++ b/awacs/s3.py
@@ -4,8 +4,8 @@ import warnings
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon S3'
 prefix = 's3'

--- a/awacs/s3_object_lambda.py
+++ b/awacs/s3_object_lambda.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon S3 Object Lambda'
 prefix = 's3-object-lambda'

--- a/awacs/s3_outposts.py
+++ b/awacs/s3_outposts.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon S3 on Outposts'
 prefix = 's3-outposts'

--- a/awacs/sagemaker.py
+++ b/awacs/sagemaker.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon SageMaker'
 prefix = 'sagemaker'

--- a/awacs/savingsplans.py
+++ b/awacs/savingsplans.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Savings Plans'
 prefix = 'savingsplans'

--- a/awacs/schemas.py
+++ b/awacs/schemas.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon EventBridge Schemas'
 prefix = 'schemas'

--- a/awacs/sdb.py
+++ b/awacs/sdb.py
@@ -4,8 +4,8 @@ import warnings
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon SimpleDB'
 prefix = 'sdb'

--- a/awacs/secretsmanager.py
+++ b/awacs/secretsmanager.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Secrets Manager'
 prefix = 'secretsmanager'

--- a/awacs/securityhub.py
+++ b/awacs/securityhub.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Security Hub'
 prefix = 'securityhub'

--- a/awacs/serverlessrepo.py
+++ b/awacs/serverlessrepo.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Serverless Application Repository'
 prefix = 'serverlessrepo'

--- a/awacs/servicecatalog.py
+++ b/awacs/servicecatalog.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Service Catalog'
 prefix = 'servicecatalog'

--- a/awacs/servicediscovery.py
+++ b/awacs/servicediscovery.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Cloud Map'
 prefix = 'servicediscovery'

--- a/awacs/servicequotas.py
+++ b/awacs/servicequotas.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Service Quotas'
 prefix = 'servicequotas'

--- a/awacs/ses.py
+++ b/awacs/ses.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon SES'
 prefix = 'ses'

--- a/awacs/shield.py
+++ b/awacs/shield.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Shield'
 prefix = 'shield'

--- a/awacs/signer.py
+++ b/awacs/signer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Signer'
 prefix = 'signer'

--- a/awacs/sms.py
+++ b/awacs/sms.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Server Migration Service'
 prefix = 'sms'

--- a/awacs/sms_voice.py
+++ b/awacs/sms_voice.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Pinpoint SMS and Voice Service'
 prefix = 'sms-voice'

--- a/awacs/snowball.py
+++ b/awacs/snowball.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Snowball'
 prefix = 'snowball'

--- a/awacs/sns.py
+++ b/awacs/sns.py
@@ -4,8 +4,8 @@ import warnings
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon SNS'
 prefix = 'sns'

--- a/awacs/sqs.py
+++ b/awacs/sqs.py
@@ -4,8 +4,8 @@ import warnings
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon SQS'
 prefix = 'sqs'

--- a/awacs/ssm.py
+++ b/awacs/ssm.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Systems Manager'
 prefix = 'ssm'

--- a/awacs/ssmmessages.py
+++ b/awacs/ssmmessages.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Session Manager Message Gateway Service'
 prefix = 'ssmmessages'

--- a/awacs/sso.py
+++ b/awacs/sso.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS SSO'
 prefix = 'sso'

--- a/awacs/sso_directory.py
+++ b/awacs/sso_directory.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS SSO Directory'
 prefix = 'sso-directory'

--- a/awacs/states.py
+++ b/awacs/states.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Step Functions'
 prefix = 'states'

--- a/awacs/storagegateway.py
+++ b/awacs/storagegateway.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Storage Gateway'
 prefix = 'storagegateway'

--- a/awacs/sts.py
+++ b/awacs/sts.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Security Token Service'
 prefix = 'sts'

--- a/awacs/sumerian.py
+++ b/awacs/sumerian.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Sumerian'
 prefix = 'sumerian'

--- a/awacs/support.py
+++ b/awacs/support.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Support'
 prefix = 'support'

--- a/awacs/swf.py
+++ b/awacs/swf.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Simple Workflow Service'
 prefix = 'swf'

--- a/awacs/synthetics.py
+++ b/awacs/synthetics.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon CloudWatch Synthetics'
 prefix = 'synthetics'

--- a/awacs/tag.py
+++ b/awacs/tag.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Resource Group Tagging API'
 prefix = 'tag'

--- a/awacs/textract.py
+++ b/awacs/textract.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Textract'
 prefix = 'textract'

--- a/awacs/timestream.py
+++ b/awacs/timestream.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Timestream'
 prefix = 'timestream'

--- a/awacs/tiros.py
+++ b/awacs/tiros.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Tiros'
 prefix = 'tiros'

--- a/awacs/transcribe.py
+++ b/awacs/transcribe.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Transcribe'
 prefix = 'transcribe'

--- a/awacs/transfer.py
+++ b/awacs/transfer.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Transfer for SFTP'
 prefix = 'transfer'

--- a/awacs/translate.py
+++ b/awacs/translate.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon Translate'
 prefix = 'translate'

--- a/awacs/trustedadvisor.py
+++ b/awacs/trustedadvisor.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Trusted Advisor'
 prefix = 'trustedadvisor'

--- a/awacs/waf.py
+++ b/awacs/waf.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS WAF'
 prefix = 'waf'

--- a/awacs/waf_regional.py
+++ b/awacs/waf_regional.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS WAF Regional'
 prefix = 'waf-regional'

--- a/awacs/wafv2.py
+++ b/awacs/wafv2.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS WAF V2'
 prefix = 'wafv2'

--- a/awacs/wam.py
+++ b/awacs/wam.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon WorkSpaces Application Manager'
 prefix = 'wam'

--- a/awacs/wellarchitected.py
+++ b/awacs/wellarchitected.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS Well-Architected Tool'
 prefix = 'wellarchitected'

--- a/awacs/workdocs.py
+++ b/awacs/workdocs.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon WorkDocs'
 prefix = 'workdocs'

--- a/awacs/worklink.py
+++ b/awacs/worklink.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon WorkLink'
 prefix = 'worklink'

--- a/awacs/workmail.py
+++ b/awacs/workmail.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon WorkMail'
 prefix = 'workmail'

--- a/awacs/workmailmessageflow.py
+++ b/awacs/workmailmessageflow.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon WorkMail Message Flow'
 prefix = 'workmailmessageflow'

--- a/awacs/workspaces.py
+++ b/awacs/workspaces.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'Amazon WorkSpaces'
 prefix = 'workspaces'

--- a/awacs/xray.py
+++ b/awacs/xray.py
@@ -3,8 +3,8 @@
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 
 service_name = 'AWS X-Ray'
 prefix = 'xray'

--- a/scrape/scrape.py
+++ b/scrape/scrape.py
@@ -18,8 +18,8 @@ HEADER = """\
 #
 # See LICENSE file for full license.
 
-from aws import Action as BaseAction
-from aws import BaseARN
+from .aws import Action as BaseAction
+from .aws import BaseARN
 """
 
 CLASSES = """\

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,8 @@ setup(
     license="New BSD license",
     packages=find_packages(),
     test_suite="tests",
-    use_2to3=True,
     requires=['slimit'],
-    python_requires=(
-        ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-    ),
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -56,9 +53,9 @@ setup(
         "Operating System :: POSIX :: Linux",
 
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 2.7",
     ],
 )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,7 +27,7 @@ def add_tests():
     # Filter out all *.py files from the examples directory
     examples = 'examples'
     regex = re.compile(r'.py$', re.I)
-    example_filesnames = filter(regex.search, os.listdir(examples))
+    example_filesnames = list(filter(regex.search, os.listdir(examples)))
 
     # Add new test functions to the TestExamples class
     for f in example_filesnames:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,7 +27,7 @@ def add_tests():
     # Filter out all *.py files from the examples directory
     examples = 'examples'
     regex = re.compile(r'.py$', re.I)
-    example_filesnames = list(filter(regex.search, os.listdir(examples)))
+    example_filesnames = filter(regex.search, os.listdir(examples))
 
     # Add new test functions to the TestExamples class
     for f in example_filesnames:


### PR DESCRIPTION
Switching awacs to Python 3 only by deprecating Python 2.x support. This removes the need for 2to3.

@michael-k could you review and approve?