### PR TITLE
Add type hints and check them with mypy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,20 @@ jobs:
           PYVERSION=$(python -c "import sys; print(''.join([str(sys.version_info.major), str(sys.version_info.minor)]))")
           python -m tox -f $(python -m tox --listenvs | grep "^py${PYVERSION}" | tr '\n' ',')
 
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip tox
+      - name: Run mypy
+        run: python -m tox -e mypy
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+.mypy_cache
 
 # C extensions
 *.so

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,5 @@ recursive-include examples *.py
 recursive-include tests *.py
 
 exclude Makefile
+exclude mypy.ini
 recursive-exclude scrape *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include *.md
 include .gitignore
 include tox.ini
+include awacs/py.typed
 recursive-include awacs *.py
 recursive-include examples *.py
 recursive-include tests *.py

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ test:
 	python -m tox -e package
 	python -m tox --listenvs | grep "^py${PYVERSION}" | tr "\n" "," | xargs python -m tox -e
 	black --check ${PYDIRS}
+	mypy awacs

--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -125,8 +125,7 @@ class AWSProperty(AWSObject):
     """
 
     def __init__(self, **kwargs):
-        sup = super(AWSProperty, self)
-        sup.__init__(None, props=self.props, **kwargs)
+        super().__init__(None, props=self.props, **kwargs)
 
 
 class AWSHelperFn:

--- a/awacs/a4b.py
+++ b/awacs/a4b.py
@@ -11,15 +11,15 @@ prefix = "a4b"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ApproveSkill = Action("ApproveSkill")

--- a/awacs/access_analyzer.py
+++ b/awacs/access_analyzer.py
@@ -11,15 +11,15 @@ prefix = "access-analyzer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ApplyArchiveRule = Action("ApplyArchiveRule")

--- a/awacs/account.py
+++ b/awacs/account.py
@@ -11,15 +11,15 @@ prefix = "account"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DisableRegion = Action("DisableRegion")

--- a/awacs/acm.py
+++ b/awacs/acm.py
@@ -11,15 +11,15 @@ prefix = "acm"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTagsToCertificate = Action("AddTagsToCertificate")

--- a/awacs/acm_pca.py
+++ b/awacs/acm_pca.py
@@ -11,15 +11,15 @@ prefix = "acm-pca"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateCertificateAuthority = Action("CreateCertificateAuthority")

--- a/awacs/activate.py
+++ b/awacs/activate.py
@@ -11,15 +11,15 @@ prefix = "activate"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateForm = Action("CreateForm")

--- a/awacs/airflow.py
+++ b/awacs/airflow.py
@@ -11,15 +11,15 @@ prefix = "airflow"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateCliToken = Action("CreateCliToken")

--- a/awacs/amplify.py
+++ b/awacs/amplify.py
@@ -11,15 +11,15 @@ prefix = "amplify"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApp = Action("CreateApp")

--- a/awacs/amplifybackend.py
+++ b/awacs/amplifybackend.py
@@ -11,15 +11,15 @@ prefix = "amplifybackend"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CloneBackend = Action("CloneBackend")

--- a/awacs/apigateway.py
+++ b/awacs/apigateway.py
@@ -11,15 +11,15 @@ prefix = "apigateway"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DELETE = Action("DELETE")

--- a/awacs/app_integrations.py
+++ b/awacs/app_integrations.py
@@ -11,15 +11,15 @@ prefix = "app-integrations"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateEventIntegration = Action("CreateEventIntegration")

--- a/awacs/appconfig.py
+++ b/awacs/appconfig.py
@@ -11,15 +11,15 @@ prefix = "appconfig"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApplication = Action("CreateApplication")

--- a/awacs/appflow.py
+++ b/awacs/appflow.py
@@ -11,15 +11,15 @@ prefix = "appflow"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateConnectorProfile = Action("CreateConnectorProfile")

--- a/awacs/application_autoscaling.py
+++ b/awacs/application_autoscaling.py
@@ -11,15 +11,15 @@ prefix = "application-autoscaling"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DeleteScalingPolicy = Action("DeleteScalingPolicy")

--- a/awacs/applicationinsights.py
+++ b/awacs/applicationinsights.py
@@ -11,15 +11,15 @@ prefix = "applicationinsights"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApplication = Action("CreateApplication")

--- a/awacs/appmesh.py
+++ b/awacs/appmesh.py
@@ -11,15 +11,15 @@ prefix = "appmesh"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateGatewayRoute = Action("CreateGatewayRoute")

--- a/awacs/appmesh_preview.py
+++ b/awacs/appmesh_preview.py
@@ -11,15 +11,15 @@ prefix = "appmesh-preview"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateGatewayRoute = Action("CreateGatewayRoute")

--- a/awacs/appstream.py
+++ b/awacs/appstream.py
@@ -11,15 +11,15 @@ prefix = "appstream"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateFleet = Action("AssociateFleet")

--- a/awacs/appsync.py
+++ b/awacs/appsync.py
@@ -11,15 +11,15 @@ prefix = "appsync"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApiKey = Action("CreateApiKey")

--- a/awacs/aps.py
+++ b/awacs/aps.py
@@ -11,15 +11,15 @@ prefix = "aps"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateWorkspace = Action("CreateWorkspace")

--- a/awacs/arsenal.py
+++ b/awacs/arsenal.py
@@ -11,15 +11,15 @@ prefix = "arsenal"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 RegisterOnPremisesAgent = Action("RegisterOnPremisesAgent")

--- a/awacs/artifact.py
+++ b/awacs/artifact.py
@@ -11,15 +11,15 @@ prefix = "artifact"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptAgreement = Action("AcceptAgreement")

--- a/awacs/athena.py
+++ b/awacs/athena.py
@@ -11,15 +11,15 @@ prefix = "athena"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchGetNamedQuery = Action("BatchGetNamedQuery")

--- a/awacs/auditmanager.py
+++ b/awacs/auditmanager.py
@@ -11,15 +11,15 @@ prefix = "auditmanager"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateAssessmentReportEvidenceFolder = Action(

--- a/awacs/autoscaling.py
+++ b/awacs/autoscaling.py
@@ -11,15 +11,15 @@ prefix = "autoscaling"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AttachInstances = Action("AttachInstances")

--- a/awacs/autoscaling_plans.py
+++ b/awacs/autoscaling_plans.py
@@ -11,15 +11,15 @@ prefix = "autoscaling-plans"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateScalingPlan = Action("CreateScalingPlan")

--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -83,7 +83,7 @@ class BaseARN(AWSHelperFn):
 
 class ARN(BaseARN):
     def __init__(self, service, resource, region="", account=""):
-        super(ARN, self).__init__(service, resource, region, account)
+        super().__init__(service, resource, region, account)
         warnings.warn(
             "This is going away. Either use a service specific "
             "ARN class, or use the BaseARN class.",
@@ -160,8 +160,7 @@ class Principal(AWSHelperFn):
 
 class AWSPrincipal(Principal):
     def __init__(self, principals):
-        sup = super(AWSPrincipal, self)
-        sup.__init__("AWS", principals)
+        super().__init__("AWS", principals)
 
 
 def effect(x):

--- a/awacs/aws_marketplace.py
+++ b/awacs/aws_marketplace.py
@@ -11,15 +11,15 @@ prefix = "aws-marketplace"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptAgreementApprovalRequest = Action("AcceptAgreementApprovalRequest")

--- a/awacs/aws_marketplace_management.py
+++ b/awacs/aws_marketplace_management.py
@@ -11,15 +11,15 @@ prefix = "aws-marketplace-management"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 uploadFiles = Action("uploadFiles")

--- a/awacs/aws_portal.py
+++ b/awacs/aws_portal.py
@@ -11,15 +11,15 @@ prefix = "aws-portal"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ModifyAccount = Action("ModifyAccount")

--- a/awacs/awsconnector.py
+++ b/awacs/awsconnector.py
@@ -11,15 +11,15 @@ prefix = "awsconnector"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 GetConnectorHealth = Action("GetConnectorHealth")

--- a/awacs/awslambda.py
+++ b/awacs/awslambda.py
@@ -11,15 +11,15 @@ prefix = "lambda"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddLayerVersionPermission = Action("AddLayerVersionPermission")

--- a/awacs/backup.py
+++ b/awacs/backup.py
@@ -11,15 +11,15 @@ prefix = "backup"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CopyFromBackupVault = Action("CopyFromBackupVault")

--- a/awacs/backup_storage.py
+++ b/awacs/backup_storage.py
@@ -11,15 +11,15 @@ prefix = "backup-storage"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 MountCapsule = Action("MountCapsule")

--- a/awacs/batch.py
+++ b/awacs/batch.py
@@ -11,15 +11,15 @@ prefix = "batch"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelJob = Action("CancelJob")

--- a/awacs/braket.py
+++ b/awacs/braket.py
@@ -11,15 +11,15 @@ prefix = "braket"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelQuantumTask = Action("CancelQuantumTask")

--- a/awacs/budgets.py
+++ b/awacs/budgets.py
@@ -11,15 +11,15 @@ prefix = "budgets"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateBudgetAction = Action("CreateBudgetAction")

--- a/awacs/cassandra.py
+++ b/awacs/cassandra.py
@@ -11,15 +11,15 @@ prefix = "cassandra"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 Alter = Action("Alter")

--- a/awacs/ce.py
+++ b/awacs/ce.py
@@ -11,15 +11,15 @@ prefix = "ce"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateAnomalyMonitor = Action("CreateAnomalyMonitor")

--- a/awacs/chatbot.py
+++ b/awacs/chatbot.py
@@ -11,15 +11,15 @@ prefix = "chatbot"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateChimeWebhookConfiguration = Action("CreateChimeWebhookConfiguration")

--- a/awacs/chime.py
+++ b/awacs/chime.py
@@ -11,15 +11,15 @@ prefix = "chime"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptDelegate = Action("AcceptDelegate")

--- a/awacs/cloud9.py
+++ b/awacs/cloud9.py
@@ -11,15 +11,15 @@ prefix = "cloud9"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateEnvironmentEC2 = Action("CreateEnvironmentEC2")

--- a/awacs/clouddirectory.py
+++ b/awacs/clouddirectory.py
@@ -11,15 +11,15 @@ prefix = "clouddirectory"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddFacetToObject = Action("AddFacetToObject")

--- a/awacs/cloudformation.py
+++ b/awacs/cloudformation.py
@@ -11,15 +11,15 @@ prefix = "cloudformation"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelUpdateStack = Action("CancelUpdateStack")

--- a/awacs/cloudfront.py
+++ b/awacs/cloudfront.py
@@ -11,15 +11,15 @@ prefix = "cloudfront"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateCachePolicy = Action("CreateCachePolicy")

--- a/awacs/cloudhsm.py
+++ b/awacs/cloudhsm.py
@@ -11,15 +11,15 @@ prefix = "cloudhsm"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTagsToResource = Action("AddTagsToResource")

--- a/awacs/cloudsearch.py
+++ b/awacs/cloudsearch.py
@@ -11,15 +11,15 @@ prefix = "cloudsearch"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTags = Action("AddTags")

--- a/awacs/cloudshell.py
+++ b/awacs/cloudshell.py
@@ -11,15 +11,15 @@ prefix = "cloudshell"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateEnvironment = Action("CreateEnvironment")

--- a/awacs/cloudtrail.py
+++ b/awacs/cloudtrail.py
@@ -11,15 +11,15 @@ prefix = "cloudtrail"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTags = Action("AddTags")

--- a/awacs/cloudwatch.py
+++ b/awacs/cloudwatch.py
@@ -11,15 +11,15 @@ prefix = "cloudwatch"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DeleteAlarms = Action("DeleteAlarms")

--- a/awacs/codeartifact.py
+++ b/awacs/codeartifact.py
@@ -11,15 +11,15 @@ prefix = "codeartifact"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateExternalConnection = Action("AssociateExternalConnection")

--- a/awacs/codebuild.py
+++ b/awacs/codebuild.py
@@ -11,15 +11,15 @@ prefix = "codebuild"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchDeleteBuilds = Action("BatchDeleteBuilds")

--- a/awacs/codecommit.py
+++ b/awacs/codecommit.py
@@ -11,15 +11,15 @@ prefix = "codecommit"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateApprovalRuleTemplateWithRepository = Action(

--- a/awacs/codedeploy.py
+++ b/awacs/codedeploy.py
@@ -11,15 +11,15 @@ prefix = "codedeploy"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTagsToOnPremisesInstances = Action("AddTagsToOnPremisesInstances")

--- a/awacs/codeguru.py
+++ b/awacs/codeguru.py
@@ -11,15 +11,15 @@ prefix = "codeguru"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 GetCodeGuruFreeTrialSummary = Action("GetCodeGuruFreeTrialSummary")

--- a/awacs/codeguru_profiler.py
+++ b/awacs/codeguru_profiler.py
@@ -11,15 +11,15 @@ prefix = "codeguru-profiler"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddNotificationChannels = Action("AddNotificationChannels")

--- a/awacs/codeguru_reviewer.py
+++ b/awacs/codeguru_reviewer.py
@@ -11,15 +11,15 @@ prefix = "codeguru-reviewer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateRepository = Action("AssociateRepository")

--- a/awacs/codepipeline.py
+++ b/awacs/codepipeline.py
@@ -11,15 +11,15 @@ prefix = "codepipeline"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcknowledgeJob = Action("AcknowledgeJob")

--- a/awacs/codestar.py
+++ b/awacs/codestar.py
@@ -11,15 +11,15 @@ prefix = "codestar"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateTeamMember = Action("AssociateTeamMember")

--- a/awacs/codestar_connections.py
+++ b/awacs/codestar_connections.py
@@ -11,15 +11,15 @@ prefix = "codestar-connections"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateConnection = Action("CreateConnection")

--- a/awacs/codestar_notifications.py
+++ b/awacs/codestar_notifications.py
@@ -11,15 +11,15 @@ prefix = "codestar-notifications"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateNotificationRule = Action("CreateNotificationRule")

--- a/awacs/cognito_identity.py
+++ b/awacs/cognito_identity.py
@@ -11,15 +11,15 @@ prefix = "cognito-identity"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateIdentityPool = Action("CreateIdentityPool")

--- a/awacs/cognito_idp.py
+++ b/awacs/cognito_idp.py
@@ -11,15 +11,15 @@ prefix = "cognito-idp"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddCustomAttributes = Action("AddCustomAttributes")

--- a/awacs/cognito_sync.py
+++ b/awacs/cognito_sync.py
@@ -11,15 +11,15 @@ prefix = "cognito-sync"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BulkPublish = Action("BulkPublish")

--- a/awacs/comprehend.py
+++ b/awacs/comprehend.py
@@ -11,15 +11,15 @@ prefix = "comprehend"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchDetectDominantLanguage = Action("BatchDetectDominantLanguage")

--- a/awacs/comprehendmedical.py
+++ b/awacs/comprehendmedical.py
@@ -11,15 +11,15 @@ prefix = "comprehendmedical"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeEntitiesDetectionV2Job = Action("DescribeEntitiesDetectionV2Job")

--- a/awacs/compute_optimizer.py
+++ b/awacs/compute_optimizer.py
@@ -11,15 +11,15 @@ prefix = "compute-optimizer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeRecommendationExportJobs = Action("DescribeRecommendationExportJobs")

--- a/awacs/config.py
+++ b/awacs/config.py
@@ -11,15 +11,15 @@ prefix = "config"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchGetAggregateResourceConfig = Action("BatchGetAggregateResourceConfig")

--- a/awacs/connect.py
+++ b/awacs/connect.py
@@ -11,15 +11,15 @@ prefix = "connect"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateApprovedOrigin = Action("AssociateApprovedOrigin")

--- a/awacs/crowd.py
+++ b/awacs/crowd.py
@@ -11,15 +11,15 @@ prefix = "crowd"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptQualificationRequest = Action("AcceptQualificationRequest")

--- a/awacs/cur.py
+++ b/awacs/cur.py
@@ -11,15 +11,15 @@ prefix = "cur"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DeleteReportDefinition = Action("DeleteReportDefinition")

--- a/awacs/databrew.py
+++ b/awacs/databrew.py
@@ -11,15 +11,15 @@ prefix = "databrew"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchDeleteRecipeVersion = Action("BatchDeleteRecipeVersion")

--- a/awacs/dataexchange.py
+++ b/awacs/dataexchange.py
@@ -11,15 +11,15 @@ prefix = "dataexchange"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelJob = Action("CancelJob")

--- a/awacs/datapipeline.py
+++ b/awacs/datapipeline.py
@@ -11,15 +11,15 @@ prefix = "datapipeline"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ActivatePipeline = Action("ActivatePipeline")

--- a/awacs/datasync.py
+++ b/awacs/datasync.py
@@ -11,15 +11,15 @@ prefix = "datasync"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelTaskExecution = Action("CancelTaskExecution")

--- a/awacs/dax.py
+++ b/awacs/dax.py
@@ -11,15 +11,15 @@ prefix = "dax"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchGetItem = Action("BatchGetItem")

--- a/awacs/dbqms.py
+++ b/awacs/dbqms.py
@@ -11,15 +11,15 @@ prefix = "dbqms"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateFavoriteQuery = Action("CreateFavoriteQuery")

--- a/awacs/deepcomposer.py
+++ b/awacs/deepcomposer.py
@@ -11,15 +11,15 @@ prefix = "deepcomposer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateCoupon = Action("AssociateCoupon")

--- a/awacs/deeplens.py
+++ b/awacs/deeplens.py
@@ -11,15 +11,15 @@ prefix = "deeplens"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateServiceRoleToAccount = Action("AssociateServiceRoleToAccount")

--- a/awacs/deepracer.py
+++ b/awacs/deepracer.py
@@ -11,15 +11,15 @@ prefix = "deepracer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CloneReinforcementLearningModel = Action("CloneReinforcementLearningModel")

--- a/awacs/detective.py
+++ b/awacs/detective.py
@@ -11,15 +11,15 @@ prefix = "detective"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptInvitation = Action("AcceptInvitation")

--- a/awacs/devicefarm.py
+++ b/awacs/devicefarm.py
@@ -11,15 +11,15 @@ prefix = "devicefarm"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateDevicePool = Action("CreateDevicePool")

--- a/awacs/devops_guru.py
+++ b/awacs/devops_guru.py
@@ -11,15 +11,15 @@ prefix = "devops-guru"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddNotificationChannel = Action("AddNotificationChannel")

--- a/awacs/directconnect.py
+++ b/awacs/directconnect.py
@@ -11,15 +11,15 @@ prefix = "directconnect"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptDirectConnectGatewayAssociationProposal = Action(

--- a/awacs/discovery.py
+++ b/awacs/discovery.py
@@ -11,15 +11,15 @@ prefix = "discovery"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateConfigurationItemsToApplication = Action(

--- a/awacs/dlm.py
+++ b/awacs/dlm.py
@@ -11,15 +11,15 @@ prefix = "dlm"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateLifecyclePolicy = Action("CreateLifecyclePolicy")

--- a/awacs/dms.py
+++ b/awacs/dms.py
@@ -11,15 +11,15 @@ prefix = "dms"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTagsToResource = Action("AddTagsToResource")

--- a/awacs/ds.py
+++ b/awacs/ds.py
@@ -11,15 +11,15 @@ prefix = "ds"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptSharedDirectory = Action("AcceptSharedDirectory")

--- a/awacs/dynamodb.py
+++ b/awacs/dynamodb.py
@@ -11,15 +11,15 @@ prefix = "dynamodb"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchGetItem = Action("BatchGetItem")

--- a/awacs/ebs.py
+++ b/awacs/ebs.py
@@ -11,15 +11,15 @@ prefix = "ebs"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CompleteSnapshot = Action("CompleteSnapshot")

--- a/awacs/ec2.py
+++ b/awacs/ec2.py
@@ -11,15 +11,15 @@ prefix = "ec2"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptReservedInstancesExchangeQuote = Action("AcceptReservedInstancesExchangeQuote")

--- a/awacs/ec2_instance_connect.py
+++ b/awacs/ec2_instance_connect.py
@@ -11,15 +11,15 @@ prefix = "ec2-instance-connect"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 SendSSHPublicKey = Action("SendSSHPublicKey")

--- a/awacs/ec2messages.py
+++ b/awacs/ec2messages.py
@@ -11,15 +11,15 @@ prefix = "ec2messages"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcknowledgeMessage = Action("AcknowledgeMessage")

--- a/awacs/ecr.py
+++ b/awacs/ecr.py
@@ -11,15 +11,15 @@ prefix = "ecr"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchCheckLayerAvailability = Action("BatchCheckLayerAvailability")

--- a/awacs/ecr_public.py
+++ b/awacs/ecr_public.py
@@ -11,15 +11,15 @@ prefix = "ecr-public"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchCheckLayerAvailability = Action("BatchCheckLayerAvailability")

--- a/awacs/ecs.py
+++ b/awacs/ecs.py
@@ -11,15 +11,15 @@ prefix = "ecs"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateCapacityProvider = Action("CreateCapacityProvider")

--- a/awacs/eks.py
+++ b/awacs/eks.py
@@ -11,15 +11,15 @@ prefix = "eks"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AccessKubernetesApi = Action("AccessKubernetesApi")

--- a/awacs/elastic_inference.py
+++ b/awacs/elastic_inference.py
@@ -11,15 +11,15 @@ prefix = "elastic-inference"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 Connect = Action("Connect")

--- a/awacs/elasticache.py
+++ b/awacs/elasticache.py
@@ -11,15 +11,15 @@ prefix = "elasticache"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTagsToResource = Action("AddTagsToResource")

--- a/awacs/elasticbeanstalk.py
+++ b/awacs/elasticbeanstalk.py
@@ -11,15 +11,15 @@ prefix = "elasticbeanstalk"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AbortEnvironmentUpdate = Action("AbortEnvironmentUpdate")

--- a/awacs/elasticfilesystem.py
+++ b/awacs/elasticfilesystem.py
@@ -11,15 +11,15 @@ prefix = "elasticfilesystem"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 Backup = Action("Backup")

--- a/awacs/elasticloadbalancing.py
+++ b/awacs/elasticloadbalancing.py
@@ -11,15 +11,15 @@ prefix = "elasticloadbalancing"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddListenerCertificates = Action("AddListenerCertificates")

--- a/awacs/elasticmapreduce.py
+++ b/awacs/elasticmapreduce.py
@@ -11,15 +11,15 @@ prefix = "elasticmapreduce"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddInstanceFleet = Action("AddInstanceFleet")

--- a/awacs/elastictranscoder.py
+++ b/awacs/elastictranscoder.py
@@ -11,15 +11,15 @@ prefix = "elastictranscoder"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelJob = Action("CancelJob")

--- a/awacs/elemental_activations.py
+++ b/awacs/elemental_activations.py
@@ -11,15 +11,15 @@ prefix = "elemental-activations"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CompleteAccountRegistration = Action("CompleteAccountRegistration")

--- a/awacs/elemental_appliances_software.py
+++ b/awacs/elemental_appliances_software.py
@@ -11,15 +11,15 @@ prefix = "elemental-appliances-software"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateQuote = Action("CreateQuote")

--- a/awacs/elemental_support_cases.py
+++ b/awacs/elemental_support_cases.py
@@ -11,15 +11,15 @@ prefix = "elemental-support-cases"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateCase = Action("CreateCase")

--- a/awacs/elemental_support_content.py
+++ b/awacs/elemental_support_content.py
@@ -11,15 +11,15 @@ prefix = "elemental-support-content"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 Query = Action("Query")

--- a/awacs/emr_containers.py
+++ b/awacs/emr_containers.py
@@ -11,15 +11,15 @@ prefix = "emr-containers"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelJobRun = Action("CancelJobRun")

--- a/awacs/es.py
+++ b/awacs/es.py
@@ -11,15 +11,15 @@ prefix = "es"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptInboundCrossClusterSearchConnection = Action(

--- a/awacs/events.py
+++ b/awacs/events.py
@@ -11,15 +11,15 @@ prefix = "events"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ActivateEventSource = Action("ActivateEventSource")

--- a/awacs/execute_api.py
+++ b/awacs/execute_api.py
@@ -11,15 +11,15 @@ prefix = "execute-api"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 InvalidateCache = Action("InvalidateCache")

--- a/awacs/firehose.py
+++ b/awacs/firehose.py
@@ -11,15 +11,15 @@ prefix = "firehose"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateDeliveryStream = Action("CreateDeliveryStream")

--- a/awacs/fis.py
+++ b/awacs/fis.py
@@ -11,15 +11,15 @@ prefix = "fis"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateExperimentTemplate = Action("CreateExperimentTemplate")

--- a/awacs/fms.py
+++ b/awacs/fms.py
@@ -11,15 +11,15 @@ prefix = "fms"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateAdminAccount = Action("AssociateAdminAccount")

--- a/awacs/forecast.py
+++ b/awacs/forecast.py
@@ -11,15 +11,15 @@ prefix = "forecast"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateDataset = Action("CreateDataset")

--- a/awacs/frauddetector.py
+++ b/awacs/frauddetector.py
@@ -11,15 +11,15 @@ prefix = "frauddetector"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchCreateVariable = Action("BatchCreateVariable")

--- a/awacs/freertos.py
+++ b/awacs/freertos.py
@@ -11,15 +11,15 @@ prefix = "freertos"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateSoftwareConfiguration = Action("CreateSoftwareConfiguration")

--- a/awacs/fsx.py
+++ b/awacs/fsx.py
@@ -11,15 +11,15 @@ prefix = "fsx"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateFileSystemAliases = Action("AssociateFileSystemAliases")

--- a/awacs/gamelift.py
+++ b/awacs/gamelift.py
@@ -11,15 +11,15 @@ prefix = "gamelift"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptMatch = Action("AcceptMatch")

--- a/awacs/geo.py
+++ b/awacs/geo.py
@@ -11,15 +11,15 @@ prefix = "geo"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateTrackerConsumer = Action("AssociateTrackerConsumer")

--- a/awacs/glacier.py
+++ b/awacs/glacier.py
@@ -11,15 +11,15 @@ prefix = "glacier"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AbortMultipartUpload = Action("AbortMultipartUpload")

--- a/awacs/globalaccelerator.py
+++ b/awacs/globalaccelerator.py
@@ -11,15 +11,15 @@ prefix = "globalaccelerator"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddCustomRoutingEndpoints = Action("AddCustomRoutingEndpoints")

--- a/awacs/glue.py
+++ b/awacs/glue.py
@@ -11,15 +11,15 @@ prefix = "glue"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchCreatePartition = Action("BatchCreatePartition")

--- a/awacs/grafana.py
+++ b/awacs/grafana.py
@@ -11,15 +11,15 @@ prefix = "grafana"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateWorkspace = Action("CreateWorkspace")

--- a/awacs/greengrass.py
+++ b/awacs/greengrass.py
@@ -11,15 +11,15 @@ prefix = "greengrass"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateRoleToGroup = Action("AssociateRoleToGroup")

--- a/awacs/groundstation.py
+++ b/awacs/groundstation.py
@@ -11,15 +11,15 @@ prefix = "groundstation"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelContact = Action("CancelContact")

--- a/awacs/groundtruthlabeling.py
+++ b/awacs/groundtruthlabeling.py
@@ -11,15 +11,15 @@ prefix = "groundtruthlabeling"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeConsoleJob = Action("DescribeConsoleJob")

--- a/awacs/guardduty.py
+++ b/awacs/guardduty.py
@@ -11,15 +11,15 @@ prefix = "guardduty"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptInvitation = Action("AcceptInvitation")

--- a/awacs/health.py
+++ b/awacs/health.py
@@ -11,15 +11,15 @@ prefix = "health"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeAffectedAccountsForOrganization = Action(

--- a/awacs/healthlake.py
+++ b/awacs/healthlake.py
@@ -11,15 +11,15 @@ prefix = "healthlake"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateFHIRDatastore = Action("CreateFHIRDatastore")

--- a/awacs/helpers/trust.py
+++ b/awacs/helpers/trust.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 from awacs import sts
 from awacs.aws import Allow, Policy, Principal, Statement
 
 
-def make_simple_assume_statement(*principals):
+def make_simple_assume_statement(*principals: Any) -> Statement:
     return Statement(
         Principal=Principal("Service", principals),
         Effect=Allow,
@@ -10,25 +12,25 @@ def make_simple_assume_statement(*principals):
     )
 
 
-def make_simple_assume_policy(*principals):
+def make_simple_assume_policy(*principals: Any) -> Policy:
     return Policy(
         Statement=[make_simple_assume_statement(*principals)], Version="2012-10-17"
     )
 
 
-def make_service_domain_name(service, region=""):
+def make_service_domain_name(service: str, region: str = "") -> str:
     """ Helper function for creating proper service domain names. """
     tld = ".com.cn" if region == "cn-north-1" else ".com"
     return "{}.amazonaws{}".format(service, tld)
 
 
-def get_codedeploy_assumerole_policy(region=""):
+def get_codedeploy_assumerole_policy(region: str = "") -> Policy:
     """ Helper function for building the AWS CodeDeploy AssumeRole Policy. """
     service = make_service_domain_name("codedeploy", region)
     return make_simple_assume_policy(service)
 
 
-def get_default_assumerole_policy(region=""):
+def get_default_assumerole_policy(region: str = "") -> Policy:
     """Helper function for building the Default AssumeRole Policy.
 
     Taken from here:
@@ -39,25 +41,25 @@ def get_default_assumerole_policy(region=""):
     return make_simple_assume_policy(service)
 
 
-def get_ecs_assumerole_policy(region=""):
+def get_ecs_assumerole_policy(region: str = "") -> Policy:
     """ Helper function for building the ECS AssumeRole Policy. """
     service = make_service_domain_name("ecs", region)
     return make_simple_assume_policy(service)
 
 
-def get_ecs_task_assumerole_policy(region=""):
+def get_ecs_task_assumerole_policy(region: str = "") -> Policy:
     """ Helper function for building the AssumeRole Policy for ECS Tasks. """
     service = make_service_domain_name("ecs-tasks", region)
     return make_simple_assume_policy(service)
 
 
-def get_lambda_assumerole_policy(region=""):
+def get_lambda_assumerole_policy(region: str = "") -> Policy:
     """ Helper function for building the AWS Lambda AssumeRole Policy. """
     service = make_service_domain_name("lambda", region)
     return make_simple_assume_policy(service)
 
 
-def get_lambda_edge_assumerole_policy(region=""):
+def get_lambda_edge_assumerole_policy(region: str = "") -> Policy:
     """ Helper function for building the AWS Lambda@Edge AssumeRole Policy. """
     return make_simple_assume_policy(
         *[
@@ -67,7 +69,7 @@ def get_lambda_edge_assumerole_policy(region=""):
     )
 
 
-def get_application_autoscaling_assumerole_policy(region=""):
+def get_application_autoscaling_assumerole_policy(region: str = "") -> Policy:
     """ Helper function for building the AWS Lambda AssumeRole Policy. """
     service = make_service_domain_name("application-autoscaling", region)
     return make_simple_assume_policy(service)

--- a/awacs/honeycode.py
+++ b/awacs/honeycode.py
@@ -11,15 +11,15 @@ prefix = "honeycode"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ApproveTeamAssociation = Action("ApproveTeamAssociation")

--- a/awacs/iam.py
+++ b/awacs/iam.py
@@ -11,15 +11,15 @@ prefix = "iam"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddClientIDToOpenIDConnectProvider = Action("AddClientIDToOpenIDConnectProvider")

--- a/awacs/identitystore.py
+++ b/awacs/identitystore.py
@@ -11,15 +11,15 @@ prefix = "identitystore"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeGroup = Action("DescribeGroup")

--- a/awacs/imagebuilder.py
+++ b/awacs/imagebuilder.py
@@ -11,15 +11,15 @@ prefix = "imagebuilder"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelImageCreation = Action("CancelImageCreation")

--- a/awacs/importexport.py
+++ b/awacs/importexport.py
@@ -11,15 +11,15 @@ prefix = "importexport"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelJob = Action("CancelJob")

--- a/awacs/inspector.py
+++ b/awacs/inspector.py
@@ -11,15 +11,15 @@ prefix = "inspector"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddAttributesToFindings = Action("AddAttributesToFindings")

--- a/awacs/iot.py
+++ b/awacs/iot.py
@@ -11,15 +11,15 @@ prefix = "iot"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptCertificateTransfer = Action("AcceptCertificateTransfer")

--- a/awacs/iot1click.py
+++ b/awacs/iot1click.py
@@ -11,15 +11,15 @@ prefix = "iot1click"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateDeviceWithPlacement = Action("AssociateDeviceWithPlacement")

--- a/awacs/iot_device_tester.py
+++ b/awacs/iot_device_tester.py
@@ -11,15 +11,15 @@ prefix = "iot-device-tester"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CheckVersion = Action("CheckVersion")

--- a/awacs/iotanalytics.py
+++ b/awacs/iotanalytics.py
@@ -11,15 +11,15 @@ prefix = "iotanalytics"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchPutMessage = Action("BatchPutMessage")

--- a/awacs/iotdeviceadvisor.py
+++ b/awacs/iotdeviceadvisor.py
@@ -11,15 +11,15 @@ prefix = "iotdeviceadvisor"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateSuiteDefinition = Action("CreateSuiteDefinition")

--- a/awacs/iotevents.py
+++ b/awacs/iotevents.py
@@ -11,15 +11,15 @@ prefix = "iotevents"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchAcknowledgeAlarm = Action("BatchAcknowledgeAlarm")

--- a/awacs/iotfleethub.py
+++ b/awacs/iotfleethub.py
@@ -11,15 +11,15 @@ prefix = "iotfleethub"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApplication = Action("CreateApplication")

--- a/awacs/iotsitewise.py
+++ b/awacs/iotsitewise.py
@@ -11,15 +11,15 @@ prefix = "iotsitewise"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateAssets = Action("AssociateAssets")

--- a/awacs/iotthingsgraph.py
+++ b/awacs/iotthingsgraph.py
@@ -11,15 +11,15 @@ prefix = "iotthingsgraph"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateEntityToThing = Action("AssociateEntityToThing")

--- a/awacs/iotwireless.py
+++ b/awacs/iotwireless.py
@@ -11,15 +11,15 @@ prefix = "iotwireless"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateAwsAccountWithPartnerAccount = Action("AssociateAwsAccountWithPartnerAccount")

--- a/awacs/iq.py
+++ b/awacs/iq.py
@@ -11,15 +11,15 @@ prefix = "iq"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateProject = Action("CreateProject")

--- a/awacs/iq_permission.py
+++ b/awacs/iq_permission.py
@@ -11,15 +11,15 @@ prefix = "iq-permission"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ApproveAccessGrant = Action("ApproveAccessGrant")

--- a/awacs/ivs.py
+++ b/awacs/ivs.py
@@ -11,15 +11,15 @@ prefix = "ivs"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchGetChannel = Action("BatchGetChannel")

--- a/awacs/kafka.py
+++ b/awacs/kafka.py
@@ -11,15 +11,15 @@ prefix = "kafka"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchAssociateScramSecret = Action("BatchAssociateScramSecret")

--- a/awacs/kendra.py
+++ b/awacs/kendra.py
@@ -11,15 +11,15 @@ prefix = "kendra"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchDeleteDocument = Action("BatchDeleteDocument")

--- a/awacs/kinesis.py
+++ b/awacs/kinesis.py
@@ -11,15 +11,15 @@ prefix = "kinesis"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTagsToStream = Action("AddTagsToStream")

--- a/awacs/kinesisanalytics.py
+++ b/awacs/kinesisanalytics.py
@@ -11,15 +11,15 @@ prefix = "kinesisanalytics"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddApplicationCloudWatchLoggingOption = Action("AddApplicationCloudWatchLoggingOption")

--- a/awacs/kinesisvideo.py
+++ b/awacs/kinesisvideo.py
@@ -11,15 +11,15 @@ prefix = "kinesisvideo"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ConnectAsMaster = Action("ConnectAsMaster")

--- a/awacs/kms.py
+++ b/awacs/kms.py
@@ -11,15 +11,15 @@ prefix = "kms"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelKeyDeletion = Action("CancelKeyDeletion")

--- a/awacs/lakeformation.py
+++ b/awacs/lakeformation.py
@@ -11,15 +11,15 @@ prefix = "lakeformation"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchGrantPermissions = Action("BatchGrantPermissions")

--- a/awacs/launchwizard.py
+++ b/awacs/launchwizard.py
@@ -11,15 +11,15 @@ prefix = "launchwizard"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DeleteApp = Action("DeleteApp")

--- a/awacs/lex.py
+++ b/awacs/lex.py
@@ -11,15 +11,15 @@ prefix = "lex"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BuildBotLocale = Action("BuildBotLocale")

--- a/awacs/license_manager.py
+++ b/awacs/license_manager.py
@@ -11,15 +11,15 @@ prefix = "license-manager"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptGrant = Action("AcceptGrant")

--- a/awacs/lightsail.py
+++ b/awacs/lightsail.py
@@ -11,15 +11,15 @@ prefix = "lightsail"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AllocateStaticIp = Action("AllocateStaticIp")

--- a/awacs/logs.py
+++ b/awacs/logs.py
@@ -11,15 +11,15 @@ prefix = "logs"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateKmsKey = Action("AssociateKmsKey")

--- a/awacs/lookoutequipment.py
+++ b/awacs/lookoutequipment.py
@@ -11,15 +11,15 @@ prefix = "lookoutequipment"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateDataset = Action("CreateDataset")

--- a/awacs/lookoutmetrics.py
+++ b/awacs/lookoutmetrics.py
@@ -11,15 +11,15 @@ prefix = "lookoutmetrics"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ActivateAnomalyDetector = Action("ActivateAnomalyDetector")

--- a/awacs/lookoutvision.py
+++ b/awacs/lookoutvision.py
@@ -11,15 +11,15 @@ prefix = "lookoutvision"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateDataset = Action("CreateDataset")

--- a/awacs/machinelearning.py
+++ b/awacs/machinelearning.py
@@ -11,15 +11,15 @@ prefix = "machinelearning"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTags = Action("AddTags")

--- a/awacs/macie.py
+++ b/awacs/macie.py
@@ -11,15 +11,15 @@ prefix = "macie"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptInvitation = Action("AcceptInvitation")

--- a/awacs/macie2.py
+++ b/awacs/macie2.py
@@ -11,15 +11,15 @@ prefix = "macie2"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptInvitation = Action("AcceptInvitation")

--- a/awacs/managedblockchain.py
+++ b/awacs/managedblockchain.py
@@ -11,15 +11,15 @@ prefix = "managedblockchain"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateMember = Action("CreateMember")

--- a/awacs/marketplacecommerceanalytics.py
+++ b/awacs/marketplacecommerceanalytics.py
@@ -11,15 +11,15 @@ prefix = "marketplacecommerceanalytics"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 GenerateDataSet = Action("GenerateDataSet")

--- a/awacs/mechanicalturk.py
+++ b/awacs/mechanicalturk.py
@@ -11,15 +11,15 @@ prefix = "mechanicalturk"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptQualificationRequest = Action("AcceptQualificationRequest")

--- a/awacs/mediaconnect.py
+++ b/awacs/mediaconnect.py
@@ -11,15 +11,15 @@ prefix = "mediaconnect"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddFlowOutputs = Action("AddFlowOutputs")

--- a/awacs/mediaconvert.py
+++ b/awacs/mediaconvert.py
@@ -11,15 +11,15 @@ prefix = "mediaconvert"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateCertificate = Action("AssociateCertificate")

--- a/awacs/medialive.py
+++ b/awacs/medialive.py
@@ -11,15 +11,15 @@ prefix = "medialive"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptInputDeviceTransfer = Action("AcceptInputDeviceTransfer")

--- a/awacs/mediapackage.py
+++ b/awacs/mediapackage.py
@@ -11,15 +11,15 @@ prefix = "mediapackage"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateChannel = Action("CreateChannel")

--- a/awacs/mediapackage_vod.py
+++ b/awacs/mediapackage_vod.py
@@ -11,15 +11,15 @@ prefix = "mediapackage-vod"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateAsset = Action("CreateAsset")

--- a/awacs/mediastore.py
+++ b/awacs/mediastore.py
@@ -11,15 +11,15 @@ prefix = "mediastore"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateContainer = Action("CreateContainer")

--- a/awacs/mediatailor.py
+++ b/awacs/mediatailor.py
@@ -11,15 +11,15 @@ prefix = "mediatailor"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DeletePlaybackConfiguration = Action("DeletePlaybackConfiguration")

--- a/awacs/mgh.py
+++ b/awacs/mgh.py
@@ -11,15 +11,15 @@ prefix = "mgh"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateCreatedArtifact = Action("AssociateCreatedArtifact")

--- a/awacs/mobileanalytics.py
+++ b/awacs/mobileanalytics.py
@@ -11,15 +11,15 @@ prefix = "mobileanalytics"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 GetFinancialReports = Action("GetFinancialReports")

--- a/awacs/mobilehub.py
+++ b/awacs/mobilehub.py
@@ -11,15 +11,15 @@ prefix = "mobilehub"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateProject = Action("CreateProject")

--- a/awacs/mobiletargeting.py
+++ b/awacs/mobiletargeting.py
@@ -11,15 +11,15 @@ prefix = "mobiletargeting"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApp = Action("CreateApp")

--- a/awacs/monitron.py
+++ b/awacs/monitron.py
@@ -11,15 +11,15 @@ prefix = "monitron"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateProjectAdminUser = Action("AssociateProjectAdminUser")

--- a/awacs/mq.py
+++ b/awacs/mq.py
@@ -11,15 +11,15 @@ prefix = "mq"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateBroker = Action("CreateBroker")

--- a/awacs/neptune_db.py
+++ b/awacs/neptune_db.py
@@ -11,15 +11,15 @@ prefix = "neptune-db"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 connect = Action("connect")

--- a/awacs/network_firewall.py
+++ b/awacs/network_firewall.py
@@ -11,15 +11,15 @@ prefix = "network-firewall"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateFirewallPolicy = Action("AssociateFirewallPolicy")

--- a/awacs/networkmanager.py
+++ b/awacs/networkmanager.py
@@ -11,15 +11,15 @@ prefix = "networkmanager"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateCustomerGateway = Action("AssociateCustomerGateway")

--- a/awacs/opsworks.py
+++ b/awacs/opsworks.py
@@ -11,15 +11,15 @@ prefix = "opsworks"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssignInstance = Action("AssignInstance")

--- a/awacs/opsworks_cm.py
+++ b/awacs/opsworks_cm.py
@@ -11,15 +11,15 @@ prefix = "opsworks-cm"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateNode = Action("AssociateNode")

--- a/awacs/organizations.py
+++ b/awacs/organizations.py
@@ -11,15 +11,15 @@ prefix = "organizations"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptHandshake = Action("AcceptHandshake")

--- a/awacs/outposts.py
+++ b/awacs/outposts.py
@@ -11,15 +11,15 @@ prefix = "outposts"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateOutpost = Action("CreateOutpost")

--- a/awacs/panorama.py
+++ b/awacs/panorama.py
@@ -11,15 +11,15 @@ prefix = "panorama"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApp = Action("CreateApp")

--- a/awacs/personalize.py
+++ b/awacs/personalize.py
@@ -11,15 +11,15 @@ prefix = "personalize"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateBatchInferenceJob = Action("CreateBatchInferenceJob")

--- a/awacs/pi.py
+++ b/awacs/pi.py
@@ -11,15 +11,15 @@ prefix = "pi"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeDimensionKeys = Action("DescribeDimensionKeys")

--- a/awacs/polly.py
+++ b/awacs/polly.py
@@ -11,15 +11,15 @@ prefix = "polly"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DeleteLexicon = Action("DeleteLexicon")

--- a/awacs/pricing.py
+++ b/awacs/pricing.py
@@ -11,15 +11,15 @@ prefix = "pricing"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeServices = Action("DescribeServices")

--- a/awacs/profile.py
+++ b/awacs/profile.py
@@ -11,15 +11,15 @@ prefix = "profile"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddProfileKey = Action("AddProfileKey")

--- a/awacs/proton.py
+++ b/awacs/proton.py
@@ -11,15 +11,15 @@ prefix = "proton"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateEnvironment = Action("CreateEnvironment")

--- a/awacs/purchase_orders.py
+++ b/awacs/purchase_orders.py
@@ -11,15 +11,15 @@ prefix = "purchase-orders"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ModifyPurchaseOrders = Action("ModifyPurchaseOrders")

--- a/awacs/qldb.py
+++ b/awacs/qldb.py
@@ -11,15 +11,15 @@ prefix = "qldb"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelJournalKinesisStream = Action("CancelJournalKinesisStream")

--- a/awacs/quicksight.py
+++ b/awacs/quicksight.py
@@ -11,15 +11,15 @@ prefix = "quicksight"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelIngestion = Action("CancelIngestion")

--- a/awacs/ram.py
+++ b/awacs/ram.py
@@ -11,15 +11,15 @@ prefix = "ram"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptResourceShareInvitation = Action("AcceptResourceShareInvitation")

--- a/awacs/rds.py
+++ b/awacs/rds.py
@@ -11,15 +11,15 @@ prefix = "rds"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddRoleToDBCluster = Action("AddRoleToDBCluster")

--- a/awacs/rds_data.py
+++ b/awacs/rds_data.py
@@ -11,15 +11,15 @@ prefix = "rds-data"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchExecuteStatement = Action("BatchExecuteStatement")

--- a/awacs/rds_db.py
+++ b/awacs/rds_db.py
@@ -11,15 +11,15 @@ prefix = "rds-db"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 connect = Action("connect")

--- a/awacs/redshift.py
+++ b/awacs/redshift.py
@@ -11,15 +11,15 @@ prefix = "redshift"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptReservedNodeExchange = Action("AcceptReservedNodeExchange")

--- a/awacs/redshift_data.py
+++ b/awacs/redshift_data.py
@@ -11,15 +11,15 @@ prefix = "redshift-data"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelStatement = Action("CancelStatement")

--- a/awacs/rekognition.py
+++ b/awacs/rekognition.py
@@ -11,15 +11,15 @@ prefix = "rekognition"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CompareFaces = Action("CompareFaces")

--- a/awacs/resource_explorer.py
+++ b/awacs/resource_explorer.py
@@ -11,15 +11,15 @@ prefix = "resource-explorer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ListResourceTypes = Action("ListResourceTypes")

--- a/awacs/resource_groups.py
+++ b/awacs/resource_groups.py
@@ -11,15 +11,15 @@ prefix = "resource-groups"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateGroup = Action("CreateGroup")

--- a/awacs/robomaker.py
+++ b/awacs/robomaker.py
@@ -11,15 +11,15 @@ prefix = "robomaker"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchDeleteWorlds = Action("BatchDeleteWorlds")

--- a/awacs/route53.py
+++ b/awacs/route53.py
@@ -11,15 +11,15 @@ prefix = "route53"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateVPCWithHostedZone = Action("AssociateVPCWithHostedZone")

--- a/awacs/route53domains.py
+++ b/awacs/route53domains.py
@@ -11,15 +11,15 @@ prefix = "route53domains"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CheckDomainAvailability = Action("CheckDomainAvailability")

--- a/awacs/route53resolver.py
+++ b/awacs/route53resolver.py
@@ -11,15 +11,15 @@ prefix = "route53resolver"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateResolverEndpointIpAddress = Action("AssociateResolverEndpointIpAddress")

--- a/awacs/s3.py
+++ b/awacs/s3.py
@@ -11,17 +11,14 @@ prefix = "s3"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
         # account is empty for S3
-        account = ""
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+        super().__init__(service=prefix, resource=resource, region=region, account="")
 
 
 AbortMultipartUpload = Action("AbortMultipartUpload")

--- a/awacs/s3_object_lambda.py
+++ b/awacs/s3_object_lambda.py
@@ -11,15 +11,15 @@ prefix = "s3-object-lambda"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AbortMultipartUpload = Action("AbortMultipartUpload")

--- a/awacs/s3_outposts.py
+++ b/awacs/s3_outposts.py
@@ -11,15 +11,15 @@ prefix = "s3-outposts"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AbortMultipartUpload = Action("AbortMultipartUpload")

--- a/awacs/sagemaker.py
+++ b/awacs/sagemaker.py
@@ -11,15 +11,15 @@ prefix = "sagemaker"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddAssociation = Action("AddAssociation")

--- a/awacs/savingsplans.py
+++ b/awacs/savingsplans.py
@@ -11,15 +11,15 @@ prefix = "savingsplans"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateSavingsPlan = Action("CreateSavingsPlan")

--- a/awacs/schemas.py
+++ b/awacs/schemas.py
@@ -11,15 +11,15 @@ prefix = "schemas"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateDiscoverer = Action("CreateDiscoverer")

--- a/awacs/sdb.py
+++ b/awacs/sdb.py
@@ -11,15 +11,15 @@ prefix = "sdb"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchDeleteAttributes = Action("BatchDeleteAttributes")

--- a/awacs/secretsmanager.py
+++ b/awacs/secretsmanager.py
@@ -11,15 +11,15 @@ prefix = "secretsmanager"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelRotateSecret = Action("CancelRotateSecret")

--- a/awacs/securityhub.py
+++ b/awacs/securityhub.py
@@ -11,15 +11,15 @@ prefix = "securityhub"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptInvitation = Action("AcceptInvitation")

--- a/awacs/serverlessrepo.py
+++ b/awacs/serverlessrepo.py
@@ -11,15 +11,15 @@ prefix = "serverlessrepo"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApplication = Action("CreateApplication")

--- a/awacs/servicecatalog.py
+++ b/awacs/servicecatalog.py
@@ -11,15 +11,15 @@ prefix = "servicecatalog"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AcceptPortfolioShare = Action("AcceptPortfolioShare")

--- a/awacs/servicediscovery.py
+++ b/awacs/servicediscovery.py
@@ -11,15 +11,15 @@ prefix = "servicediscovery"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateHttpNamespace = Action("CreateHttpNamespace")

--- a/awacs/servicequotas.py
+++ b/awacs/servicequotas.py
@@ -11,15 +11,15 @@ prefix = "servicequotas"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateServiceQuotaTemplate = Action("AssociateServiceQuotaTemplate")

--- a/awacs/ses.py
+++ b/awacs/ses.py
@@ -11,15 +11,15 @@ prefix = "ses"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CloneReceiptRuleSet = Action("CloneReceiptRuleSet")

--- a/awacs/shield.py
+++ b/awacs/shield.py
@@ -11,15 +11,15 @@ prefix = "shield"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateDRTLogBucket = Action("AssociateDRTLogBucket")

--- a/awacs/signer.py
+++ b/awacs/signer.py
@@ -11,15 +11,15 @@ prefix = "signer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddProfilePermission = Action("AddProfilePermission")

--- a/awacs/sms.py
+++ b/awacs/sms.py
@@ -11,15 +11,15 @@ prefix = "sms"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateApp = Action("CreateApp")

--- a/awacs/sms_voice.py
+++ b/awacs/sms_voice.py
@@ -11,15 +11,15 @@ prefix = "sms-voice"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateConfigurationSet = Action("CreateConfigurationSet")

--- a/awacs/snowball.py
+++ b/awacs/snowball.py
@@ -11,15 +11,15 @@ prefix = "snowball"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelCluster = Action("CancelCluster")

--- a/awacs/sns.py
+++ b/awacs/sns.py
@@ -11,15 +11,15 @@ prefix = "sns"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddPermission = Action("AddPermission")

--- a/awacs/sqs.py
+++ b/awacs/sqs.py
@@ -11,15 +11,15 @@ prefix = "sqs"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddPermission = Action("AddPermission")

--- a/awacs/ssm.py
+++ b/awacs/ssm.py
@@ -11,15 +11,15 @@ prefix = "ssm"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddTagsToResource = Action("AddTagsToResource")

--- a/awacs/ssmmessages.py
+++ b/awacs/ssmmessages.py
@@ -11,15 +11,15 @@ prefix = "ssmmessages"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateControlChannel = Action("CreateControlChannel")

--- a/awacs/sso.py
+++ b/awacs/sso.py
@@ -11,15 +11,15 @@ prefix = "sso"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddMemberToGroup = Action("AddMemberToGroup")

--- a/awacs/sso_directory.py
+++ b/awacs/sso_directory.py
@@ -11,15 +11,15 @@ prefix = "sso-directory"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddMemberToGroup = Action("AddMemberToGroup")

--- a/awacs/states.py
+++ b/awacs/states.py
@@ -11,15 +11,15 @@ prefix = "states"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateActivity = Action("CreateActivity")

--- a/awacs/storagegateway.py
+++ b/awacs/storagegateway.py
@@ -11,15 +11,15 @@ prefix = "storagegateway"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 ActivateGateway = Action("ActivateGateway")

--- a/awacs/sts.py
+++ b/awacs/sts.py
@@ -11,15 +11,15 @@ prefix = "sts"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssumeRole = Action("AssumeRole")

--- a/awacs/sumerian.py
+++ b/awacs/sumerian.py
@@ -11,15 +11,15 @@ prefix = "sumerian"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 Login = Action("Login")

--- a/awacs/support.py
+++ b/awacs/support.py
@@ -11,15 +11,15 @@ prefix = "support"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddAttachmentsToSet = Action("AddAttachmentsToSet")

--- a/awacs/swf.py
+++ b/awacs/swf.py
@@ -11,15 +11,15 @@ prefix = "swf"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelTimer = Action("CancelTimer")

--- a/awacs/synthetics.py
+++ b/awacs/synthetics.py
@@ -11,15 +11,15 @@ prefix = "synthetics"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateCanary = Action("CreateCanary")

--- a/awacs/tag.py
+++ b/awacs/tag.py
@@ -11,15 +11,15 @@ prefix = "tag"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddResourceTags = Action("AddResourceTags")

--- a/awacs/textract.py
+++ b/awacs/textract.py
@@ -11,15 +11,15 @@ prefix = "textract"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AnalyzeDocument = Action("AnalyzeDocument")

--- a/awacs/timestream.py
+++ b/awacs/timestream.py
@@ -11,15 +11,15 @@ prefix = "timestream"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CancelQuery = Action("CancelQuery")

--- a/awacs/tiros.py
+++ b/awacs/tiros.py
@@ -11,15 +11,15 @@ prefix = "tiros"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateQuery = Action("CreateQuery")

--- a/awacs/transcribe.py
+++ b/awacs/transcribe.py
@@ -11,15 +11,15 @@ prefix = "transcribe"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateLanguageModel = Action("CreateLanguageModel")

--- a/awacs/transfer.py
+++ b/awacs/transfer.py
@@ -11,15 +11,15 @@ prefix = "transfer"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateServer = Action("CreateServer")

--- a/awacs/translate.py
+++ b/awacs/translate.py
@@ -11,15 +11,15 @@ prefix = "translate"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateParallelData = Action("CreateParallelData")

--- a/awacs/trustedadvisor.py
+++ b/awacs/trustedadvisor.py
@@ -11,15 +11,15 @@ prefix = "trustedadvisor"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 DescribeAccount = Action("DescribeAccount")

--- a/awacs/waf.py
+++ b/awacs/waf.py
@@ -11,15 +11,15 @@ prefix = "waf"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 CreateByteMatchSet = Action("CreateByteMatchSet")

--- a/awacs/waf_regional.py
+++ b/awacs/waf_regional.py
@@ -11,15 +11,15 @@ prefix = "waf-regional"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateWebACL = Action("AssociateWebACL")

--- a/awacs/wafv2.py
+++ b/awacs/wafv2.py
@@ -11,15 +11,15 @@ prefix = "wafv2"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateWebACL = Action("AssociateWebACL")

--- a/awacs/wam.py
+++ b/awacs/wam.py
@@ -11,15 +11,15 @@ prefix = "wam"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AuthenticatePackager = Action("AuthenticatePackager")

--- a/awacs/wellarchitected.py
+++ b/awacs/wellarchitected.py
@@ -11,15 +11,15 @@ prefix = "wellarchitected"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateLenses = Action("AssociateLenses")

--- a/awacs/workdocs.py
+++ b/awacs/workdocs.py
@@ -11,15 +11,15 @@ prefix = "workdocs"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AbortDocumentVersionUpload = Action("AbortDocumentVersionUpload")

--- a/awacs/worklink.py
+++ b/awacs/worklink.py
@@ -11,15 +11,15 @@ prefix = "worklink"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateDomain = Action("AssociateDomain")

--- a/awacs/workmail.py
+++ b/awacs/workmail.py
@@ -11,15 +11,15 @@ prefix = "workmail"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AddMembersToGroup = Action("AddMembersToGroup")

--- a/awacs/workmailmessageflow.py
+++ b/awacs/workmailmessageflow.py
@@ -11,15 +11,15 @@ prefix = "workmailmessageflow"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 GetRawMessageContent = Action("GetRawMessageContent")

--- a/awacs/workspaces.py
+++ b/awacs/workspaces.py
@@ -11,15 +11,15 @@ prefix = "workspaces"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AssociateIpGroups = Action("AssociateIpGroups")

--- a/awacs/xray.py
+++ b/awacs/xray.py
@@ -11,15 +11,15 @@ prefix = "xray"
 
 
 class Action(BaseAction):
-    def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+    def __init__(self, action: str = None) -> None:
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 BatchGetTraces = Action("BatchGetTraces")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+check_untyped_defs = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+follow_imports = silent
+ignore_missing_imports = True
+python_version = 3.6
+strict_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+show_error_codes = True

--- a/scrape/scrape.py
+++ b/scrape/scrape.py
@@ -25,29 +25,27 @@ from .aws import BaseARN
 CLASSES = """\
 class Action(BaseAction):
     def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
     def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 """
 
 CLASSES_S3 = """\
 class Action(BaseAction):
     def __init__(self, action=None):
-        sup = super(Action, self)
-        sup.__init__(prefix, action)
+        super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
     def __init__(self, resource="", region="", account=""):
         sup = super(ARN, self)
         # account is empty for S3
-        account = ""
-        sup.__init__(service=prefix, resource=resource, region=region, account=account)
+        super().__init__(service=prefix, resource=resource, region=region, account="")
 """
 
 BASEDIR = "awacs"

--- a/scrape/scrape.py
+++ b/scrape/scrape.py
@@ -24,12 +24,12 @@ from .aws import BaseARN
 
 CLASSES = """\
 class Action(BaseAction):
-    def __init__(self, action=None):
+    def __init__(self, action: str = None) -> None:
         super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
         super().__init__(
             service=prefix, resource=resource, region=region, account=account
         )
@@ -37,13 +37,12 @@ class ARN(BaseARN):
 
 CLASSES_S3 = """\
 class Action(BaseAction):
-    def __init__(self, action=None):
+    def __init__(self, action: str = None) -> None:
         super().__init__(prefix, action)
 
 
 class ARN(BaseARN):
-    def __init__(self, resource="", region="", account=""):
-        sup = super(ARN, self)
+    def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
         # account is empty for S3
         super().__init__(service=prefix, resource=resource, region=region, account="")
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,11 @@ project_urls =
 
 [options]
 include_package_data = true
+install_requires =
+    typing-extensions >= 3.7.4.3; python_version < "3.8"
 packages = find:
-python_requires = >=3.6
+# typing.Any and typing.NoReturn were added in 3.6.2
+python_requires = >=3.6.2
 zip_safe = false
 
 [pycodestyle]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,12 @@ envlist =
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning setup.py test {posargs}
 
+[testenv:mypy]
+deps =
+    mypy
+commands =
+    mypy awacs
+
 [testenv:qa]
 deps =
     pycodestyle


### PR DESCRIPTION
The file `py.typed` makes the type hints available for use in other projects.

There are still a lot of `Any`s.  In some of those cases `Any` is fine (`__eq__`, `__ne__`, …), but in others I wasn't sure if I can come up with a complete list of allowed values.  Eg. what does `Principal` accept as `resources`?  Maybe ↓?

```python
from typing import TYPE_CHECKING, Union, Sequence

if TYPE_CHECKING:
    from troposphere import Ref
    from .iam import ARN as IAM_ARN

Resources = Union[str, "IAM_ARN", "Ref", Sequence[Union[str, "IAM_ARN", "Ref"]]


class Principal(AWSHelperFn):
    def __init__(self, principal: str, resources: Resources = None) -> None:
        ...
```

`troposphere.Ref` makes it hard/impossible to properly restrict the type hints because awacs does not depend on troposphere and then `troposphere.Ref` is just `Any` for all projects that use awacs without troposphere.

----

Maybe declare (note in changelog) type hints as experimental in the next release to (formally) allow changes without the need of a major version bump.