### PR TITLE
Use PyPA's build project to build sdist and wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
           python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade "twine>=3.4.1" "wheel>=0.36.2"
+        python -m pip install --upgrade "build>=0.3.1" "twine>=3.4.1"
     - name: Build package
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel .
     - name: Check basics before uploading the package
       run: |
         python -m tox -e package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,10 @@ commands =
 
 [testenv:package]
 deps =
+    build>=0.3.1
     check_manifest>=0.46
     twine>=3.4.1
-    wheel>=0.36.2
 commands =
     python -m check_manifest
-    python setup.py sdist bdist_wheel
+    python -m build --sdist --wheel .
     twine check dist/*


### PR DESCRIPTION
A good introduction to PEP 517: https://snarky.ca/what-the-heck-is-pyproject-toml/

`build` is PyPA's recommended tool (and also maintained by PyPA) to build projects using PEP 517/518, see https://github.com/pypa/packaging-problems/issues/219#issuecomment-749724342

More information about `build` (docs, changelog, …) is available at https://pypi.org/project/build/

PEP 517: https://www.python.org/dev/peps/pep-0517/
PEP 518: https://www.python.org/dev/peps/pep-0518/