### PR TITLE
Do not remove account and region from non-bucket s3 ARNs

### DIFF
--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -73,8 +73,11 @@ class BaseARN(AWSHelperFn):
         else:
             aws_partition = "aws"
 
-        regionless = ["iam", "s3"]
-        if service in regionless:
+        if service == "iam":
+            region = ""
+        elif service == "s3" and not resource.startswith(
+            ("accesspoint/", "job/", "storage-lens/")
+        ):
             region = ""
 
         self.data = "arn:%s:%s:%s:%s:%s" % (

--- a/awacs/s3.py
+++ b/awacs/s3.py
@@ -17,8 +17,12 @@ class Action(BaseAction):
 
 class ARN(BaseARN):
     def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
-        # account is empty for S3
-        super().__init__(service=prefix, resource=resource, region=region, account="")
+        # account is empty for S3 buckets
+        if not resource.startswith(("accesspoint/", "job/", "storage-lens/")):
+            account = ""
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 
 
 AbortMultipartUpload = Action("AbortMultipartUpload")

--- a/scrape/scrape.py
+++ b/scrape/scrape.py
@@ -43,8 +43,12 @@ class Action(BaseAction):
 
 class ARN(BaseARN):
     def __init__(self, resource: str = "", region: str = "", account: str = "") -> None:
-        # account is empty for S3
-        super().__init__(service=prefix, resource=resource, region=region, account="")
+        # account is empty for S3 buckets
+        if not resource.startswith(("accesspoint/", "job/", "storage-lens/")):
+            account = ""
+        super().__init__(
+            service=prefix, resource=resource, region=region, account=account
+        )
 """
 
 BASEDIR = "awacs"

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -15,3 +15,14 @@ class TestARN(unittest.TestCase):
     def test_gov(self):
         arn = ARN("bucket/key", "us-gov-west-1", "account")
         self.assertEqual(arn.JSONrepr(), "arn:aws-us-gov:s3:::bucket/key")
+
+    def test_non_bucket_arns(self):
+        for resource in [
+            "accesspoint/my-access-point",
+            "job/job-id",
+            "storage-lens/config-id",
+        ]:
+            arn = ARN(resource, "us-east-1", "111122223333")
+            self.assertEqual(
+                arn.JSONrepr(), f"arn:aws:s3:us-east-1:111122223333:{resource}"
+            )


### PR DESCRIPTION
Doesn't solve the issue if `resource == "*"` but :shrug:.  This is hopefully backwards compatible.

Fixes cloudtools/awacs#185