### PR TITLE
Run tests against Python 3.11 and add trove classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Changelog = https://github.com/cloudtools/awacs/blob/master/CHANGELOG.md
     Source = https://github.com/cloudtools/awacs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}
+    py{36,37,38,39,310,311}
     qa,package
 
 [testenv]


### PR DESCRIPTION
released on 2022-10-24, see https://pythoninsider.blogspot.com/2022/10/python-3110-is-now-available.html