### PR TITLE
Update to_json Indent Type Annotation

### DIFF
--- a/awacs/__init__.py
+++ b/awacs/__init__.py
@@ -111,7 +111,7 @@ class AWSObject:
         self.validate()
         return self.resource
 
-    def to_json(self, indent: int = 4, sort_keys: bool = True) -> str:
+    def to_json(self, indent: Optional[int] = 4, sort_keys: bool = True) -> str:
         p = self.properties
         return json.dumps(p, cls=awsencode, indent=indent, sort_keys=sort_keys)
 
@@ -149,7 +149,7 @@ class AWSHelperFn:
         else:
             return data
 
-    def to_json(self, indent: int = 4, sort_keys: bool = True) -> str:
+    def to_json(self, indent: Optional[int] = 4, sort_keys: bool = True) -> str:
         p = self
         return json.dumps(p, cls=awsencode, indent=indent, sort_keys=sort_keys)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -50,6 +50,22 @@ class TestAWSObject(unittest.TestCase):
             "'statement'",
         )
 
+    def test_to_json(self):
+        p = PolicyDocument(Version="2012-10-17", Statement=[])
+
+        self.assertEqual(
+            p.to_json(),
+            '{\n    "Statement": [],\n    "Version": "2012-10-17"\n}',
+        )
+
+    def test_to_json_indent_non(self):
+        p = PolicyDocument(Version="2012-10-17", Statement=[])
+
+        self.assertEqual(
+            p.to_json(indent=None),
+            '{"Statement": [], "Version": "2012-10-17"}',
+        )
+
 
 class TestAWSProperty(unittest.TestCase):
     def test_prop_value_type_mismatch_expect_list(self):


### PR DESCRIPTION
Updated the `to_json` methods indent type annotation on the `AWSObject`, and `AWSHelperFn` to allow for None. Added unit tests to ensure the string representation is as expected.

[Sending an integer, or string to `json.dumps` indent parameter](https://docs.python.org/3/library/json.html#json.dump) results in a pretty printed json string with new lines in it. Sending in None results in the most compact representation.

For example:

```pycon
>>> import json
>>> json.dumps({'a': 'b'}, indent=0)
'{\n"a": "b"\n}'
>>> json.dumps({'a': 'b'}, indent=-1)
'{\n"a": "b"\n}'
>>> json.dumps({'a': 'b'}, indent='')
'{\n"a": "b"\n}'
>>> json.dumps({'a': 'b'}, indent=4)
'{\n    "a": "b"\n}'
>>> json.dumps({'a': 'b'}, indent=None)
'{"a": "b"}'
```

This change allows for the last option, sending in `None` to get the most compact representation.

I have no idea if this is a desired change, and I apologize if I should have opened an issue first. The change was so small though I figured why not just open a PR, and if this change isn't desired we can talk about it here. No worries if this isn't something desired for the code base.

Thank you!