### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-          python-version: 3.7
+          python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade "build>=0.3.1" "twine>=3.4.1"
+        python -m pip install --upgrade "build>=1.0.3" "twine>=4.0.2"
     - name: Build package
       run: |
         python -m build --sdist --wheel .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
@@ -42,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -28,10 +27,8 @@ project_urls =
 
 [options]
 include_package_data = true
-install_requires =
-    typing-extensions >= 3.7.4.3; python_version < "3.8"
 packages = find:
-python_requires = >=3.7.0
+python_requires = >=3.8
 zip_safe = false
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310,311}
+    py{38,39,310,311}
     qa,package
 
 [testenv]
@@ -23,9 +23,9 @@ commands =
 
 [testenv:package]
 deps =
-    build>=0.3.1
-    check_manifest>=0.46
-    twine>=3.4.1
+    build>=1.0.3
+    check_manifest>=0.49
+    twine>=4.0.2
 commands =
     python -m check_manifest
     python -m build --sdist --wheel .


### PR DESCRIPTION
Python 3.7 reached its EOL on 2023-06-27, see https://peps.python.org/pep-0537/#lifespan