### PR TITLE
Run tests against Python 3.14 and add trove classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
         - "3.11"
         - "3.12"
         - "3.13"
+        - "3.14.0-rc.3 - 3.14"
 
     steps:
       - uses: actions/checkout@v3

--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -11,7 +11,7 @@ from . import AWSHelperFn, AWSProperty
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal  # type: ignore[assignment]
+    from typing_extensions import Literal
 
 # Policy effect constants.
 Allow = "Allow"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 project_urls =
     Changelog = https://github.com/cloudtools/awacs/blob/master/CHANGELOG.md
     Source = https://github.com/cloudtools/awacs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312,313}
+    py{39,310,311,312,313,314}
     qa,package
 
 [testenv]


### PR DESCRIPTION
Python 3.14 is expected in about a week on 2025-10-07, see https://peps.python.org/pep-0745/